### PR TITLE
chore: remove deps, remove EnvFilter

### DIFF
--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -19,15 +19,14 @@ eyre = "0.6.8"
 file-rotate = "0.7.3"
 futures = "~0.3.13"
 hex = "~0.4.3"
-libp2p = { version="0.51", features = ["tokio", "dns", "kad", "macros", "mdns", "mplex", "noise", "quic", "request-response", "tcp", "websocket", "yamux",] }
+libp2p = { version="0.51", features = ["tokio", "dns", "kad", "macros", "mdns", "quic", "request-response",] }
 libp2p-quic = { version = "0.7.0-alpha.3", features = ["tokio"] }
 rmp-serde = "1.1.1"
 serde = {version = "1.0.133", features = [ "derive", "rc" ]}
-serde_json = "1.0.94"
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }
-tracing-subscriber = {version= "0.3.16", features=["env-filter"]}
+tracing-subscriber = "0.3.16"
 tracing-appender = "~0.2.0"
 tracing-core = "0.1.30"
 walkdir = "2.3.1"

--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -32,7 +32,7 @@ regex = "1.7.1"
 tonic = { version = "~0.8.3", optional = true }
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
-tracing-subscriber = { version = "~0.3.1", features = ["env-filter", "json"] }
+tracing-subscriber = "~0.3.1"
 xor_name = { version = "~5.0.0", optional = true }
 walkdir = "2"
 

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -39,9 +39,7 @@ use std::{
     process::{Command, Stdio},
 };
 use tracing::{debug, info};
-use tracing_subscriber::EnvFilter;
 
-const BASE_TRACING_DIRECTIVES: &str = "sn_testnet=debug";
 const DEFAULT_NODE_COUNT: u32 = 25;
 
 #[derive(Debug, clap::StructOpt)]
@@ -259,30 +257,7 @@ async fn join_network(
 }
 
 fn init_tracing() -> Result<()> {
-    let mut filter = EnvFilter::try_new(BASE_TRACING_DIRECTIVES)
-        .map_err(|_| eyre!("BUG: hard-coded tracing directives are invalid"))?;
-
-    let extra_directives = std::env::var(EnvFilter::DEFAULT_ENV)
-        .map_or_else(
-            |error| match error {
-                std::env::VarError::NotPresent => Ok(None),
-                std::env::VarError::NotUnicode(_) => Err(eyre!(error)),
-            },
-            |filter| Ok(Some(EnvFilter::try_new(filter)?)),
-        )
-        .map_err(|_| eyre!("Invalid value for {}", EnvFilter::DEFAULT_ENV))?;
-
-    if let Some(extra_directives) = extra_directives {
-        for directive in extra_directives.to_string().split(',') {
-            filter = filter.add_directive(
-                directive
-                    .parse()
-                    .expect("BUG: invalid directive in parsed EnvFilter"),
-            );
-        }
-    }
-
-    tracing_subscriber::fmt().with_env_filter(filter).init();
+    tracing_subscriber::fmt().init();
 
     Ok(())
 }


### PR DESCRIPTION
We can specify log levels in the code as needed without having to bring in EnvFilter (and regex).

Although right now regex is used elsewhere, we can hopefully remove that large dep