### PR TITLE
chore: various minor adjustments

### DIFF
--- a/safenode/src/bin/kadnode.rs
+++ b/safenode/src/bin/kadnode.rs
@@ -43,7 +43,6 @@ async fn main() -> Result<()> {
     let (node, node_events_channel) = Node::run().await?;
 
     let mut node_events_rx = node_events_channel.subscribe();
-    // wait until we connect to the network
     if let Ok(event) = node_events_rx.recv().await {
         match event {
             NodeEvent::ConnectedToNetwork => {

--- a/safenode/src/network/cmd.rs
+++ b/safenode/src/network/cmd.rs
@@ -11,7 +11,7 @@ use crate::{
     protocol::messages::{Request, Response},
 };
 
-use super::{error::Error, NetworkSwarmLoop};
+use super::{error::Error, SwarmDriver};
 use libp2p::{multiaddr::Protocol, request_response::ResponseChannel, Multiaddr, PeerId};
 use std::collections::{hash_map, HashSet};
 use tokio::sync::oneshot;
@@ -45,7 +45,7 @@ pub enum SwarmCmd {
     },
 }
 
-impl NetworkSwarmLoop {
+impl SwarmDriver {
     pub(crate) fn handle_cmd(&mut self, cmd: SwarmCmd) -> Result<(), Error> {
         match cmd {
             SwarmCmd::StartListening { addr, sender } => {

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -9,7 +9,7 @@
 use super::{
     error::{Error, Result},
     msg::MsgCodec,
-    NetworkSwarmLoop,
+    SwarmDriver,
 };
 
 use crate::protocol::messages::{Request, Response};
@@ -69,7 +69,7 @@ pub enum NetworkEvent {
     PeerAdded,
 }
 
-impl NetworkSwarmLoop {
+impl SwarmDriver {
     // Handle `SwarmEvents`
     pub(super) async fn handle_swarm_events<EventError: std::error::Error>(
         &mut self,

--- a/safenode/src/network/msg/mod.rs
+++ b/safenode/src/network/msg/mod.rs
@@ -9,12 +9,12 @@
 mod codec;
 pub(crate) use codec::{MsgCodec, MsgProtocol};
 
-use crate::network::{error::Error, NetworkEvent, NetworkSwarmLoop};
+use crate::network::{error::Error, NetworkEvent, SwarmDriver};
 use crate::protocol::messages::{Request, Response};
 use libp2p::request_response::{self, Message};
 use tracing::{trace, warn};
 
-impl NetworkSwarmLoop {
+impl SwarmDriver {
     /// Forwards `Request` to the upper layers using `Sender<NetworkEvent>`. Sends `Response` to the peers
     pub async fn handle_msg(
         &mut self,


### PR DESCRIPTION
While making an effort to understand the node start up and the different async tasks in use, I noticed small adjustments I thought I could make to perhaps improve clarity.

* Rename: `NetworkSwarmLoop` to `SwarmDriver`, which then provides the loop in its `run` function.
* Use GPT-4 to document `SwarmDriver` and its public functions. Did not need any adjustment.
* Rename some variables in `SwarmDriver::new` for extra clarity.
* Rename `Node::node_events_channel` to `Node::events_channel` since it's part of the `Node` struct.
* Use GPT-4 to document `Node` and its public functions. Did not need any adjustment.
* Removed comments that appeared to provide limited value.