### PR TITLE
refactor(node): don't have client fn on nodes

### DIFF
--- a/safenode/src/bin/kadnode.rs
+++ b/safenode/src/bin/kadnode.rs
@@ -6,31 +6,29 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use bincode::serialize;
-use bls::SecretKey;
-use bytes::Bytes;
-use clap::Parser;
-use eyre::{eyre, Result};
-use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 use safenode::{
     log::init_node_logging,
     network::Network,
-    node::{Node, NodeEvent},
+    node::{Client, Node, NodeEvent},
     protocol::{
-        messages::{
-            CreateRegister, EditRegister, RegisterCmd, ReplicatedData, SignedRegisterCreate,
-            SignedRegisterEdit,
-        },
+        messages::{CreateRegister, EditRegister, SignedRegisterCreate, SignedRegisterEdit},
         types::{
+            address::ChunkAddress,
             authority::DataAuthority,
             chunk::Chunk,
             register::{Policy, Register, User},
         },
     },
 };
-use std::{collections::BTreeSet, fs, path::PathBuf};
-use std::{thread, time};
-use tracing::info;
+
+use bincode::serialize;
+use bls::SecretKey;
+use bytes::Bytes;
+use clap::Parser;
+use eyre::{eyre, Result};
+use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
+use std::{collections::BTreeSet, fs, path::PathBuf, thread, time};
+use tracing::{info, warn};
 use walkdir::WalkDir;
 use xor_name::XorName;
 
@@ -39,7 +37,7 @@ async fn main() -> Result<()> {
     let opt = Opt::parse();
     let _log_appender_guard = init_node_logging(&opt.log_dir)?;
 
-    info!("Starting node...");
+    info!("Starting a node...");
     let (node, node_events_channel) = Node::run().await?;
 
     let mut node_events_rx = node_events_channel.subscribe();
@@ -51,6 +49,24 @@ async fn main() -> Result<()> {
         }
     }
 
+    let run_node = {
+        opt.upload_chunks.is_none()
+            && !opt.create_register
+            && opt.entry.is_none()
+            && opt.get_chunk.is_none()
+    };
+
+    if run_node {
+        // Do not process client tasks.
+        // but keep the node running.
+        loop {
+            thread::sleep(time::Duration::from_millis(100));
+        }
+    }
+
+    info!("Instantiating a client...");
+    let client = Client::new(node);
+
     if let Some(files_path) = opt.upload_chunks {
         for entry in WalkDir::new(files_path).into_iter().flatten() {
             if entry.file_type().is_file() {
@@ -61,20 +77,26 @@ async fn main() -> Result<()> {
                     "Storing chunk {:?} with xorname: {xor_name:x}",
                     entry.file_name()
                 );
-                node.store_data(&ReplicatedData::Chunk(chunk)).await?;
-                info!("Successfully stored chunk");
+                match client.store_chunk(chunk).await {
+                    Ok(()) => info!("Successfully stored chunk"),
+                    Err(error) => {
+                        warn!("Did not store chunk to all nodes in the close group! {error}")
+                    }
+                };
             }
         }
     }
 
     if let Some(xor_name) = opt.get_chunk {
-        info!("trying to get chunk");
-        let vec = hex::decode(xor_name).expect("failed to decode xorname");
+        info!("Trying to get chunk {xor_name}...");
+        let vec = hex::decode(xor_name).expect("Failed to decode xorname!");
         let mut xor_name = XorName::default();
         xor_name.0.copy_from_slice(vec.as_slice());
 
-        node.get_chunk(xor_name).await?;
-        info!("Successfully got chunk");
+        match client.get_chunk(ChunkAddress::new(xor_name)).await {
+            Ok(chunk) => info!("Successfully got chunk {}!", chunk.name()),
+            Err(error) => warn!("Did not get any chunk from the close group! {error}"),
+        };
     }
 
     if opt.create_register {
@@ -99,9 +121,12 @@ async fn main() -> Result<()> {
             signature: sk.sign(serialize(&op)?),
         };
 
-        let cmd = RegisterCmd::Create(SignedRegisterCreate { op, auth });
+        let cmd = SignedRegisterCreate { op, auth };
 
-        node.store_data(&ReplicatedData::RegisterWrite(cmd)).await?;
+        match client.create_register(cmd).await {
+            Ok(()) => info!("Successfully created register {xor_name}, {tag}!"),
+            Err(error) => warn!("Did not create register on all nodes in the close group! {error}"),
+        };
 
         if let Some(entry) = opt.entry {
             let mut register = Register::new(owner, xor_name, tag, policy);
@@ -115,13 +140,18 @@ async fn main() -> Result<()> {
                 signature: sk.sign(serialize(&op)?),
             };
 
-            let cmd = RegisterCmd::Edit(SignedRegisterEdit { op, auth });
+            let cmd = SignedRegisterEdit { op, auth };
 
-            node.store_data(&ReplicatedData::RegisterWrite(cmd)).await?;
+            match client.edit_register(cmd).await {
+                Ok(()) => info!("Successfully edited register {xor_name}, {tag}!"),
+                Err(error) => {
+                    warn!("Did not edit register on all nodes in the close group! {error}")
+                }
+            };
         }
     }
 
-    // Keep the node running
+    // Keep the client running.
     loop {
         thread::sleep(time::Duration::from_millis(100));
     }

--- a/safenode/src/node/error.rs
+++ b/safenode/src/node/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     Network(#[from] crate::network::Error),
 
     #[error("Protocol error {0}")]
-    Protocol(#[from] crate::protocol::types::errors::Error),
+    Protocol(#[from] crate::protocol::types::error::Error),
 
     #[error("Other Error {0}")]
     Other(String),

--- a/safenode/src/protocol/messages/cmd.rs
+++ b/safenode/src/protocol/messages/cmd.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::protocol::types::address::{ChunkAddress, DataAddress};
+
 use super::{super::types::chunk::Chunk, RegisterCmd};
 use serde::{Deserialize, Serialize};
 
@@ -25,4 +27,15 @@ pub enum Cmd {
     ///
     /// [`Register`]: crate::protocol::types::register::Register
     Register(RegisterCmd),
+}
+
+impl Cmd {
+    /// Used to send a cmd to the close group of the address.
+    pub fn dst(&self) -> DataAddress {
+        match self {
+            Cmd::StoreChunk(chunk) => DataAddress::Chunk(ChunkAddress::new(*chunk.name())),
+            Cmd::Register(cmd) => DataAddress::Register(cmd.dst()),
+            // Cmd::GetDbc(address) => DataAddress::Spentbook(*address)
+        }
+    }
 }

--- a/safenode/src/protocol/messages/mod.rs
+++ b/safenode/src/protocol/messages/mod.rs
@@ -30,19 +30,19 @@ use xor_name::XorName;
 /// Send a request to other peers in the network
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Request {
-    /// A (read-only) query sent to nodes.
-    Query(Query),
     /// Messages that lead to mutation.
     Cmd(Cmd),
+    /// A (read-only) query sent to nodes.
+    Query(Query),
 }
 
 /// Respond to other peers in the network
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Response {
-    /// The response to a query.
-    Query(QueryResponse),
     /// The response to a cmd.
     Cmd(CmdResponse),
+    /// The response to a query.
+    Query(QueryResponse),
 }
 
 /// Messages to replicated data among nodes on the network
@@ -56,22 +56,32 @@ pub enum ReplicatedData {
     RegisterLog(ReplicatedRegisterLog),
 }
 
+impl Request {
+    /// Used to send a request to the close group of the address.
+    pub fn dst(&self) -> DataAddress {
+        match self {
+            Request::Cmd(cmd) => cmd.dst(),
+            Request::Query(query) => query.dst(),
+        }
+    }
+}
+
 impl ReplicatedData {
-    /// Returns the name.
+    /// Return the name.
     pub fn name(&self) -> XorName {
         match self {
             Self::Chunk(chunk) => *chunk.name(),
             Self::RegisterLog(log) => *log.address.name(),
-            Self::RegisterWrite(cmd) => *cmd.dst_address().name(),
+            Self::RegisterWrite(cmd) => *cmd.dst().name(),
         }
     }
 
-    /// Returns the address.
-    pub fn address(&self) -> DataAddress {
+    /// Return the dst.
+    pub fn dst(&self) -> DataAddress {
         match self {
-            Self::Chunk(chunk) => DataAddress::Bytes(*chunk.address()),
+            Self::Chunk(chunk) => DataAddress::Chunk(*chunk.address()),
             Self::RegisterLog(log) => DataAddress::Register(log.address),
-            Self::RegisterWrite(cmd) => DataAddress::Register(cmd.dst_address()),
+            Self::RegisterWrite(cmd) => DataAddress::Register(cmd.dst()),
         }
     }
 }

--- a/safenode/src/protocol/messages/query.rs
+++ b/safenode/src/protocol/messages/query.rs
@@ -6,10 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{super::types::address::ChunkAddress, register::RegisterQuery};
+use super::{
+    super::types::address::{ChunkAddress, DataAddress, SpentbookAddress},
+    register::RegisterQuery,
+};
 
 use serde::{Deserialize, Serialize};
-use xor_name::XorName;
 
 /// Data queries - retrieving data and inspecting their structure.
 ///
@@ -32,5 +34,16 @@ pub enum Query {
     /// [`Register`]: crate::protocol::types::register::Register
     Register(RegisterQuery),
     /// todo: impl entire DataStorage struct
-    GetDbc(XorName),
+    GetDbc(SpentbookAddress),
+}
+
+impl Query {
+    /// Used to send a query to the close group of the address.
+    pub fn dst(&self) -> DataAddress {
+        match self {
+            Query::GetChunk(address) => DataAddress::Chunk(*address),
+            Query::Register(query) => DataAddress::Register(query.dst()),
+            Query::GetDbc(address) => DataAddress::Spentbook(*address),
+        }
+    }
 }

--- a/safenode/src/protocol/messages/register.rs
+++ b/safenode/src/protocol/messages/register.rs
@@ -106,7 +106,7 @@ impl CreateRegister {
     }
 
     /// Returns the address of the register.
-    pub fn address(&self) -> RegisterAddress {
+    pub fn dst(&self) -> RegisterAddress {
         RegisterAddress {
             name: self.name,
             tag: self.tag,
@@ -147,21 +147,21 @@ pub struct SignedRegisterEdit {
 
 impl SignedRegisterCreate {
     /// Returns the dst address of the register.
-    pub fn dst_address(&self) -> RegisterAddress {
-        self.op.address()
+    pub fn dst(&self) -> RegisterAddress {
+        self.op.dst()
     }
 }
 
 impl SignedRegisterEdit {
     /// Returns the dst address of the register.
-    pub fn dst_address(&self) -> RegisterAddress {
+    pub fn dst(&self) -> RegisterAddress {
         self.op.address
     }
 }
 
 impl RegisterQuery {
     /// Returns the dst address for the request.
-    pub fn dst_address(&self) -> RegisterAddress {
+    pub fn dst(&self) -> RegisterAddress {
         match self {
             Self::Get(ref address)
             | Self::Read(ref address)
@@ -177,14 +177,14 @@ impl RegisterCmd {
     /// Returns the name of the register.
     /// This is not a unique identifier.
     pub fn name(&self) -> XorName {
-        *self.dst_address().name()
+        *self.dst().name()
     }
 
     /// Returns the dst address of the register.
-    pub fn dst_address(&self) -> RegisterAddress {
+    pub fn dst(&self) -> RegisterAddress {
         match self {
-            Self::Create(cmd) => cmd.dst_address(),
-            Self::Edit(cmd) => cmd.dst_address(),
+            Self::Create(cmd) => cmd.dst(),
+            Self::Edit(cmd) => cmd.dst(),
         }
     }
 }

--- a/safenode/src/protocol/messages/response.rs
+++ b/safenode/src/protocol/messages/response.rs
@@ -8,7 +8,7 @@
 
 use super::super::types::{
     chunk::Chunk,
-    errors::Result,
+    error::Result,
     register::{Entry, EntryHash, Permissions, Policy, Register, User},
 };
 

--- a/safenode/src/protocol/types/address/mod.rs
+++ b/safenode/src/protocol/types/address/mod.rs
@@ -21,7 +21,7 @@ use xor_name::XorName;
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub enum DataAddress {
     ///
-    Bytes(ChunkAddress),
+    Chunk(ChunkAddress),
     ///
     Register(RegisterAddress),
     ///
@@ -32,7 +32,7 @@ impl DataAddress {
     /// The xorname.
     pub fn name(&self) -> &XorName {
         match self {
-            Self::Bytes(address) => address.name(),
+            Self::Chunk(address) => address.name(),
             Self::Register(address) => address.name(),
             Self::Spentbook(address) => address.name(),
         }
@@ -44,7 +44,7 @@ impl DataAddress {
     }
 
     ///
-    pub fn bytes(name: XorName) -> Self {
-        Self::Bytes(ChunkAddress::new(name))
+    pub fn chunk(name: XorName) -> Self {
+        Self::Chunk(ChunkAddress::new(name))
     }
 }

--- a/safenode/src/protocol/types/authority.rs
+++ b/safenode/src/protocol/types/authority.rs
@@ -8,7 +8,7 @@
 
 pub use bls::{PublicKey, Signature};
 
-use super::errors::{Error, Result};
+use super::error::{Error, Result};
 
 use serde::{Deserialize, Serialize};
 

--- a/safenode/src/protocol/types/error.rs
+++ b/safenode/src/protocol/types/error.rs
@@ -7,14 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    address::RegisterAddress,
+    address::{ChunkAddress, RegisterAddress},
     authority::PublicKey,
     register::{EntryHash, User},
 };
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, result};
 use thiserror::Error;
-use xor_name::XorName;
 
 /// A specialised `Result` type for types crate.
 pub type Result<T> = result::Result<T, Error>;
@@ -31,10 +30,13 @@ pub enum Error {
     Serialisation(String),
     /// Chunk not found.
     #[error("Chunk not found: {0:?}")]
-    ChunkNotFound(XorName),
+    ChunkNotFound(ChunkAddress),
     /// Register not found.
     #[error("Register not found: {0:?}")]
     RegisterNotFound(RegisterAddress),
+    /// Unexpected responses.
+    #[error("Unexpected responses")]
+    UnexpectedResponses,
     /// Entry is too big to fit inside a register
     #[error("Entry is too big to fit inside a register: {size}, max: {max}")]
     EntryTooBig {

--- a/safenode/src/protocol/types/mod.rs
+++ b/safenode/src/protocol/types/mod.rs
@@ -13,6 +13,6 @@ pub mod authority;
 /// Chunk type
 pub mod chunk;
 /// Errors
-pub mod errors;
+pub mod error;
 /// Register type
 pub mod register;

--- a/safenode/src/protocol/types/register/mod.rs
+++ b/safenode/src/protocol/types/register/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use reg_crdt::{CrdtOperation, RegisterCrdt};
 
 use super::{
     super::types::address::RegisterAddress,
-    errors::{Error, Result},
+    error::{Error, Result},
 };
 
 use self_encryption::MIN_ENCRYPTABLE_BYTES;
@@ -172,7 +172,7 @@ impl Register {
 #[cfg(test)]
 mod tests {
     use super::super::{
-        errors::{Error, Result},
+        error::{Error, Result},
         register::{
             Entry, EntryHash, Permissions, Policy, Register, RegisterAddress, RegisterOp, User,
             MAX_REG_NUM_ENTRIES,

--- a/safenode/src/protocol/types/register/policy.rs
+++ b/safenode/src/protocol/types/register/policy.rs
@@ -9,7 +9,7 @@
 use super::{
     super::{
         authority::PublicKey,
-        errors::{Error, Result},
+        error::{Error, Result},
     },
     Action,
 };

--- a/safenode/src/protocol/types/register/reg_crdt.rs
+++ b/safenode/src/protocol/types/register/reg_crdt.rs
@@ -10,7 +10,7 @@ use super::{
     super::{
         address::RegisterAddress,
         authority::Signature,
-        errors::{Error, Result},
+        error::{Error, Result},
     },
     Entry, User,
 };

--- a/safenode/src/storage/chunks.rs
+++ b/safenode/src/storage/chunks.rs
@@ -9,7 +9,7 @@
 use crate::protocol::types::{
     address::ChunkAddress,
     chunk::Chunk,
-    errors::{Error, Result},
+    error::{Error, Result},
 };
 
 use clru::CLruCache;
@@ -52,7 +52,7 @@ impl ChunkStorage {
         if self.cache.write().await.pop(address).is_some() {
             Ok(())
         } else {
-            Err(Error::ChunkNotFound(*address.name()))
+            Err(Error::ChunkNotFound(*address))
         }
     }
 
@@ -62,7 +62,7 @@ impl ChunkStorage {
         if let Some(chunk) = self.cache.read().await.peek(address) {
             Ok(chunk.clone())
         } else {
-            Err(Error::ChunkNotFound(*address.name()))
+            Err(Error::ChunkNotFound(*address))
         }
     }
 

--- a/safenode/src/storage/mod.rs
+++ b/safenode/src/storage/mod.rs
@@ -38,9 +38,8 @@ impl DataStorage {
     }
 
     /// Store data in the local store and return `CmdResponse`
-    pub async fn store(&self, cmd: &Cmd) -> CmdResponse {
-        debug!("Replicating {cmd:?}");
-
+    pub async fn write(&self, cmd: &Cmd) -> CmdResponse {
+        debug!("Write {cmd:?}");
         match cmd {
             Cmd::StoreChunk(chunk) => CmdResponse::StoreChunk(self.chunks.store(chunk).await),
             Cmd::Register(cmd) => {
@@ -54,8 +53,8 @@ impl DataStorage {
     }
 
     /// Query the local store and return `QueryResponse`
-    pub async fn query(&self, query: &Query, requester: User) -> QueryResponse {
-        debug!("Query {query:?}");
+    pub async fn read(&self, query: &Query, requester: User) -> QueryResponse {
+        debug!("Read {query:?}");
         match query {
             Query::GetChunk(addr) => QueryResponse::GetChunk(self.chunks.get(addr).await),
             Query::Register(read) => self.registers.read(read, requester).await,

--- a/safenode/src/storage/register_store.rs
+++ b/safenode/src/storage/register_store.rs
@@ -10,7 +10,7 @@ use crate::protocol::{
     messages::RegisterCmd,
     types::{
         address::RegisterAddress,
-        errors::{Error, Result},
+        error::{Error, Result},
         register::Register,
     },
 };


### PR DESCRIPTION
This implements a `Client` and removes the client-specific logic from `Node`.