### PR TITLE
feat(dbcs): integrate to the system

### DIFF
--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -28,7 +28,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 self_encryption = "~0.28.0"
 serde = {version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { git = "https://github.com/oetyng/sn_dbc", branch = "remove-section-signatures", features = ["serdes"] }
+sn_dbc = { git = "https://github.com/oetyng/sn_dbc", branch = "include-dbctx-in-spend", features = ["serdes"] }
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }

--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -28,6 +28,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 self_encryption = "~0.28.0"
 serde = {version = "1.0.133", features = [ "derive", "rc" ]}
+sn_dbc = { git = "https://github.com/oetyng/sn_dbc", branch = "remove-section-signatures", features = ["serdes"] }
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }

--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -27,8 +27,8 @@ libp2p-quic = { version = "0.7.0-alpha.3", features = ["tokio"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 self_encryption = "~0.28.0"
-serde = {version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { git = "https://github.com/oetyng/sn_dbc", branch = "include-dbctx-in-spend", features = ["serdes"] }
+serde = { version = "1.0.133", features = [ "derive", "rc" ]}
+sn_dbc = { version = "15.0.0", features = ["serdes"] }
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }

--- a/safenode/src/lib.rs
+++ b/safenode/src/lib.rs
@@ -42,13 +42,13 @@
 #[macro_use]
 extern crate tracing;
 
-/// Log
+/// Logging.
 pub mod log;
-/// Network
+/// The main logic of the network.
 pub mod network;
 /// Node
 pub mod node;
 /// SAFE Protocol
 pub mod protocol;
-/// Storage
+/// Storage for chunks and registers.
 pub mod storage;

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -12,12 +12,23 @@ use crate::{
     network::{NetworkEvent, SwarmDriver},
     protocol::{
         messages::{Cmd, CmdResponse, Query, QueryResponse, Request, Response},
-        types::register::User,
+        types::{
+            address::{dbc_address, DbcAddress},
+            error::Error as ProtocolError,
+            register::User,
+            spend::Spend,
+        },
     },
     storage::DataStorage,
 };
 
-use libp2p::request_response::ResponseChannel;
+use futures::future::select_all;
+use libp2p::{request_response::ResponseChannel, PeerId};
+use sn_dbc::SignedSpend;
+use std::{
+    collections::{BTreeSet, HashSet},
+    time::Duration,
+};
 use tokio::task::spawn;
 
 impl Node {
@@ -31,18 +42,6 @@ impl Node {
     pub async fn read(&self, query: &Query) -> QueryResponse {
         self.storage.read(query, User::Anyone).await
     }
-
-    // /// Return the closest nodes
-    // pub async fn get_closest(&self, xor_name: XorName) -> Result<HashSet<PeerId>> {
-    //     info!("Getting the closest peers to {:?}", xor_name);
-
-    //     let closest_peers = self
-    //         .network
-    //         .get_closest_peers(xor_name)
-    //         .await?;
-
-    //     Ok(closest_peers)
-    // }
 
     /// Asynchronously runs a new node instance, setting up the swarm driver,
     /// creating a data storage, and handling network events. Returns the
@@ -106,6 +105,13 @@ impl Node {
     ) -> Result<()> {
         trace!("Handling request: {request:?}");
         match request {
+            Request::Cmd(Cmd::Dbc(spend)) => {
+                // First we need to validate the parents of the spend.
+                self.validate_spend_parents(&spend).await?;
+                let resp = self.storage.write(&Cmd::Dbc(spend)).await;
+                self.send_response(Response::Cmd(resp), response_channel)
+                    .await;
+            }
             Request::Cmd(cmd) => {
                 let resp = self.storage.write(&cmd).await;
                 self.send_response(Response::Cmd(resp), response_channel)
@@ -121,9 +127,143 @@ impl Node {
         Ok(())
     }
 
+    async fn validate_spend_parents(&self, spend: &Spend) -> Result<()> {
+        for input in &spend.signed_spend().spend.tx.inputs {
+            // We validate each input.
+            // input.verify(msg, blinded_amount)
+            // Here is supposedly one and the same spend from its close group.
+            // If we receive a spend here, it is assumed to be valid.
+            let parent_address = dbc_address(&input.dbc_id());
+            let parent_spend_by_close_group = self.get_spend(parent_address).await?;
+            // We serialize the transaction.
+            let msg = parent_spend_by_close_group.spend.tx.gen_message();
+
+            // We check that the input is the expected one, i.e. it has the
+            // same amount as the valid parent spend that we got from the parent spend close group.
+            match input.verify(&msg, *parent_spend_by_close_group.blinded_amount()) {
+                Ok(_) => continue,
+                Err(_) => {
+                    return Err(super::Error::Protocol(ProtocolError::InvalidSpendParent(
+                        parent_address,
+                    )))
+                }
+            };
+
+            // TODO: Do we need more validation of the input parent??
+        }
+
+        Ok(())
+    }
+
+    /// Retrieve a `Spend` from the closest peers
+    async fn get_spend(&self, address: DbcAddress) -> Result<SignedSpend> {
+        let request = Request::Query(Query::GetDbcSpend(address));
+        info!("Getting the closest peers to {:?}", request.dst());
+
+        let closest_peers = self
+            .network
+            .get_closest_peers(*request.dst().name())
+            .await?;
+        // We must know that this size is always the required/expected one.
+        let close_group_size = closest_peers.len();
+
+        let responses = self
+            .send_req_and_get_responses(closest_peers, &request, true)
+            .await;
+
+        let spends: Vec<_> = responses
+            .iter()
+            .flatten()
+            .flat_map(|resp| {
+                if let Response::Query(QueryResponse::GetDbcSpend(Ok(signed_spend))) = resp {
+                    Some(signed_spend.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if spends.len() >= close_group_size {
+            // All nodes in the close group returned a response.
+            let spends: BTreeSet<_> = spends.into_iter().collect();
+            // All nodes in the close group returned
+            // the same spend. It is thus valid.
+            if spends.len() == 1 {
+                return Ok(spends
+                    .first()
+                    .expect("This will contain a single item, due to the check before this.")
+                    .clone());
+            }
+            // Different spends returned, the parent is not valid.
+        }
+
+        // The parent is not recognised by all peers in its close group.
+        // Thus, the parent is not valid.
+        info!("The spend could not be verified as valid: {address:?}");
+
+        // If not enough spends were gotten, we try error the first
+        // error to the expected query returned from nodes.
+        for resp in responses.iter().flatten() {
+            if let Response::Query(QueryResponse::GetDbcSpend(result)) = resp {
+                let _ = result.clone()?;
+            };
+        }
+
+        // If there were no success or fail to the expected query,
+        // we check if there were any send errors.
+        for resp in responses {
+            let _ = resp?;
+        }
+
+        // If there was none of the above, then we had unexpected responses.
+        Err(super::Error::Protocol(ProtocolError::UnexpectedResponses))
+    }
+
     async fn send_response(&mut self, resp: Response, response_channel: ResponseChannel<Response>) {
         if let Err(err) = self.network.send_response(resp, response_channel).await {
             warn!("Error while sending response: {err:?}");
         }
+    }
+
+    // Send a `Request` to the provided set of nodes and wait for their responses concurrently.
+    // If `get_all_responses` is true, we wait for the responses from all the nodes. Will return an
+    // error if the request timeouts.
+    // If `get_all_responses` is false, we return the first successful response that we get
+    pub(super) async fn send_req_and_get_responses(
+        &self,
+        nodes: HashSet<PeerId>,
+        req: &Request,
+        get_all_responses: bool,
+    ) -> Vec<Result<Response>> {
+        let mut list_of_futures = Vec::new();
+        for node in nodes {
+            let future = Box::pin(tokio::time::timeout(
+                Duration::from_secs(10),
+                self.network.send_request(req.clone(), node),
+            ));
+            list_of_futures.push(future);
+        }
+
+        let mut responses = Vec::new();
+        while !list_of_futures.is_empty() {
+            match select_all(list_of_futures).await {
+                (Ok(res), _, remaining_futures) => {
+                    let res = res.map_err(super::Error::Network);
+                    info!("Got response for the req: {req:?}, res: {res:?}");
+                    // return the first successful response
+                    if !get_all_responses && res.is_ok() {
+                        return vec![res];
+                    }
+                    responses.push(res);
+                    list_of_futures = remaining_futures;
+                }
+                (Err(timeout_err), _, remaining_futures) => {
+                    responses.push(Err(super::Error::ResponseTimeout(timeout_err)));
+                    list_of_futures = remaining_futures;
+                }
+            }
+        }
+
+        responses
     }
 }

--- a/safenode/src/node/mod.rs
+++ b/safenode/src/node/mod.rs
@@ -72,13 +72,17 @@ impl Client {
             return Ok(());
         }
 
-        // If not all were Ok, we will return the first
-        // error we find.
-        for resp in responses {
-            let response = resp?;
-            if let Response::Cmd(CmdResponse::StoreChunk(result)) = response {
-                result?;
+        // If not all were Ok, we will return the first error sent to us.
+        for resp in responses.iter().flatten() {
+            if let Response::Cmd(CmdResponse::StoreChunk(result)) = resp {
+                result.clone()?;
             };
+        }
+
+        // If there were no success or fail to the expected query,
+        // we check if there were any send errors.
+        for resp in responses {
+            let _ = resp?;
         }
 
         // If there were no store chunk errors, then we had unexpected responses.
@@ -98,13 +102,17 @@ impl Client {
             return Ok(());
         }
 
-        // If not all were Ok, we will return the first
-        // error we find.
-        for resp in responses {
-            let response = resp?;
-            if let Response::Cmd(CmdResponse::CreateRegister(result)) = response {
-                result?;
+        // If not all were Ok, we will return the first error sent to us.
+        for resp in responses.iter().flatten() {
+            if let Response::Cmd(CmdResponse::CreateRegister(result)) = resp {
+                result.clone()?;
             };
+        }
+
+        // If there were no success or fail to the expected query,
+        // we check if there were any send errors.
+        for resp in responses {
+            let _ = resp?;
         }
 
         // If there were no register errors, then we had unexpected responses.
@@ -124,13 +132,17 @@ impl Client {
             return Ok(());
         }
 
-        // If not all were Ok, we will return the first
-        // error we find.
-        for resp in responses {
-            let response = resp?;
-            if let Response::Cmd(CmdResponse::EditRegister(result)) = response {
-                result?;
+        // If not all were Ok, we will return the first error sent to us.
+        for resp in responses.iter().flatten() {
+            if let Response::Cmd(CmdResponse::EditRegister(result)) = resp {
+                result.clone()?;
             };
+        }
+
+        // If there were no success or fail to the expected query,
+        // we check if there were any send errors.
+        for resp in responses {
+            let _ = resp?;
         }
 
         // If there were no register errors, then we had unexpected responses.
@@ -150,8 +162,7 @@ impl Client {
             };
         }
 
-        // If no chunk was gotten, we try error the first
-        // error to the expected query returned from nodes.
+        // If no chunk was found, we will return the first error sent to us.
         for resp in responses.iter().flatten() {
             if let Response::Query(QueryResponse::GetChunk(result)) = resp {
                 let _ = result.clone()?;
@@ -181,8 +192,7 @@ impl Client {
             };
         }
 
-        // If no register was gotten, we try error the first
-        // error to the expected query returned from nodes.
+        // If no register was gotten, we will return the first error sent to us.
         for resp in responses.iter().flatten() {
             if let Response::Query(QueryResponse::GetChunk(result)) = resp {
                 let _ = result.clone()?;

--- a/safenode/src/node/mod.rs
+++ b/safenode/src/node/mod.rs
@@ -34,10 +34,6 @@ use crate::{
     storage::DataStorage,
 };
 
-use futures::future::select_all;
-use libp2p::PeerId;
-use std::{collections::HashSet, time::Duration};
-
 /// `Node` represents a single node in the distributed network. It handles
 /// network events, processes incoming requests, interacts with the data
 /// storage, and broadcasts node-related events.
@@ -211,49 +207,8 @@ impl Client {
             .get_closest_peers(*request.dst().name())
             .await?;
         Ok(self
+            .node
             .send_req_and_get_responses(closest_peers, &request, true)
             .await)
-    }
-
-    // Send a `Request` to the provided set of nodes and wait for their responses concurrently.
-    // If `get_all_responses` is true, we wait for the responses from all the nodes. Will return an
-    // error if the request timeouts.
-    // If `get_all_responses` is false, we return the first successful response that we get
-    async fn send_req_and_get_responses(
-        &self,
-        nodes: HashSet<PeerId>,
-        req: &Request,
-        get_all_responses: bool,
-    ) -> Vec<Result<Response>> {
-        let mut list_of_futures = Vec::new();
-        for node in nodes {
-            let future = Box::pin(tokio::time::timeout(
-                Duration::from_secs(10),
-                self.node.network.send_request(req.clone(), node),
-            ));
-            list_of_futures.push(future);
-        }
-
-        let mut responses = Vec::new();
-        while !list_of_futures.is_empty() {
-            match select_all(list_of_futures).await {
-                (Ok(res), _, remaining_futures) => {
-                    let res = res.map_err(Error::Network);
-                    info!("Got response for the req: {req:?}, res: {res:?}");
-                    // return the first successful response
-                    if !get_all_responses && res.is_ok() {
-                        return vec![res];
-                    }
-                    responses.push(res);
-                    list_of_futures = remaining_futures;
-                }
-                (Err(timeout_err), _, remaining_futures) => {
-                    responses.push(Err(Error::ResponseTimeout(timeout_err)));
-                    list_of_futures = remaining_futures;
-                }
-            }
-        }
-
-        responses
     }
 }

--- a/safenode/src/protocol/messages/cmd.rs
+++ b/safenode/src/protocol/messages/cmd.rs
@@ -6,7 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::protocol::types::address::{ChunkAddress, DataAddress};
+use crate::protocol::types::{
+    address::{ChunkAddress, DataAddress},
+    spend::Spend,
+};
 
 use super::{super::types::chunk::Chunk, RegisterCmd};
 use serde::{Deserialize, Serialize};
@@ -17,8 +20,13 @@ use serde::{Deserialize, Serialize};
 /// Network, and their semantics.
 ///
 /// [`types`]: crate::protocol::types
+#[allow(clippy::large_enum_variant)]
 #[derive(Eq, PartialEq, Clone, Serialize, Deserialize, Debug)]
 pub enum Cmd {
+    /// [`Spend`] write operation.
+    ///
+    /// [`Spend`]: crate::protocol::types::spend::Spend
+    Dbc(Spend),
     /// [`Chunk`] write operation.
     ///
     /// [`Chunk`]: crate::protocol::types::chunk::Chunk
@@ -35,7 +43,7 @@ impl Cmd {
         match self {
             Cmd::StoreChunk(chunk) => DataAddress::Chunk(ChunkAddress::new(*chunk.name())),
             Cmd::Register(cmd) => DataAddress::Register(cmd.dst()),
-            // Cmd::GetDbc(address) => DataAddress::Spentbook(*address)
+            Cmd::Dbc(spend) => DataAddress::Spend(*spend.address()),
         }
     }
 }

--- a/safenode/src/protocol/messages/query.rs
+++ b/safenode/src/protocol/messages/query.rs
@@ -6,11 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{
-    super::types::address::{ChunkAddress, DataAddress, SpentbookAddress},
-    register::RegisterQuery,
+use crate::protocol::{
+    messages::RegisterQuery,
+    types::address::{ChunkAddress, DataAddress, DbcAddress},
 };
-
 use serde::{Deserialize, Serialize};
 
 /// Data queries - retrieving data and inspecting their structure.
@@ -33,8 +32,10 @@ pub enum Query {
     ///
     /// [`Register`]: crate::protocol::types::register::Register
     Register(RegisterQuery),
-    /// todo: impl entire DataStorage struct
-    GetDbc(SpentbookAddress),
+    /// [`Spend`] read operation.
+    ///
+    /// [`Spend`]: sn_dbc::SignedSpend.
+    GetDbcSpend(DbcAddress),
 }
 
 impl Query {
@@ -43,7 +44,7 @@ impl Query {
         match self {
             Query::GetChunk(address) => DataAddress::Chunk(*address),
             Query::Register(query) => DataAddress::Register(query.dst()),
-            Query::GetDbc(address) => DataAddress::Spentbook(*address),
+            Query::GetDbcSpend(address) => DataAddress::Spend(*address),
         }
     }
 }

--- a/safenode/src/protocol/messages/register.rs
+++ b/safenode/src/protocol/messages/register.rs
@@ -6,13 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::super::types::{
+use crate::protocol::types::{
     address::RegisterAddress,
     authority::DataAuthority,
     register::{Entry, EntryHash, Policy, RegisterOp, User},
 };
 #[allow(unused_imports)] // needed by rustdocs links
-use super::super::{messages::QueryResponse, types::register::Register};
+use crate::protocol::{messages::QueryResponse, types::register::Register};
 
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;

--- a/safenode/src/protocol/messages/response.rs
+++ b/safenode/src/protocol/messages/response.rs
@@ -6,14 +6,16 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::super::types::{
+use crate::protocol::types::{
     chunk::Chunk,
     error::Result,
     register::{Entry, EntryHash, Permissions, Policy, Register, User},
 };
 
 #[allow(unused_imports)] // needed by rustdocs links
-use super::super::messages::RegisterQuery;
+use crate::protocol::messages::RegisterQuery;
+
+use sn_dbc::SignedSpend;
 
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, fmt::Debug};
@@ -22,6 +24,19 @@ use std::{collections::BTreeSet, fmt::Debug};
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QueryResponse {
+    //
+    // ===== DBC Data =====
+    //
+    /// If the queried node has validated a corresponding spend
+    /// request, it will return the SignedSpend.
+    /// It is up to the Client to get this SignedSpend from enough
+    /// nodes as to consider it a valid spend. The specific rules
+    /// on how many nodes are enough, are found here: (TODO).
+    ///
+    /// Response to [`GetDbcSpend`]
+    ///
+    /// [`GetDbcSpend`]: crate::protocol::messages::Query::GetDbcSpend
+    GetDbcSpend(Result<SignedSpend>),
     //
     // ===== Chunk =====
     //
@@ -44,16 +59,16 @@ pub enum QueryResponse {
     GetRegisterPolicy(Result<Policy>),
     /// Response to [`RegisterQuery::GetUserPermissions`].
     GetRegisterUserPermissions(Result<Permissions>),
-    //
-    // ===== DBC Data =====
-    //
-    // /// todo: impl entire DataStorage struct
-    // Dbc(Dbc),
 }
 
 /// The response to a Cmd, containing the query result.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CmdResponse {
+    //
+    // ===== Dbc Spends =====
+    //
+    /// Response to DbcCmd::Spend.
+    Spend(Result<()>),
     //
     // ===== Chunk =====
     //

--- a/safenode/src/protocol/types/address/dbc.rs
+++ b/safenode/src/protocol/types/address/dbc.rs
@@ -7,22 +7,35 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use serde::{Deserialize, Serialize};
+use sn_dbc::DbcId;
 use std::hash::Hash;
 use xor_name::XorName;
 
-/// Address of a Spentbook.
+/// The address of a Dbc in the network.
+/// This is used to find information of if it is spent, not to store the actual Dbc.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
-pub struct SpentbookAddress(XorName);
+pub struct DbcAddress(XorName);
 
-impl SpentbookAddress {
-    /// Constructs a new `SpentbookAddress` given `name`.
+impl DbcAddress {
+    /// Construct a `DbcAddress` given the name of a `DbcId`.
     pub fn new(name: XorName) -> Self {
         Self(name)
     }
 
-    /// Returns the name.
-    /// This is a unique identifier.
+    /// Returns the name, which is the `DbcId` XorName.
     pub fn name(&self) -> &XorName {
         &self.0
     }
+}
+
+/// Still thinking of best location for this.
+/// Wanted to make the DbcAddress take a dbc id actually..
+pub fn dbc_address(dbc_id: &DbcId) -> DbcAddress {
+    DbcAddress::new(dbc_name(dbc_id))
+}
+
+/// Still thinking of best location for this.
+/// Wanted to make the DbcAddress take a dbc id actually..
+pub fn dbc_name(dbc_id: &DbcId) -> XorName {
+    XorName::from_content(&dbc_id.to_bytes())
 }

--- a/safenode/src/protocol/types/address/mod.rs
+++ b/safenode/src/protocol/types/address/mod.rs
@@ -7,17 +7,18 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 mod chunk;
+mod dbc;
 mod register;
-mod spentbook;
 
 pub use chunk::ChunkAddress;
+pub use dbc::{dbc_address, dbc_name, DbcAddress};
 pub use register::RegisterAddress;
-pub use spentbook::SpentbookAddress;
 
 use serde::{Deserialize, Serialize};
+use sn_dbc::DbcId;
 use xor_name::XorName;
 
-/// An address of data on the network
+/// An address of data on the network.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub enum DataAddress {
     ///
@@ -25,7 +26,7 @@ pub enum DataAddress {
     ///
     Register(RegisterAddress),
     ///
-    Spentbook(SpentbookAddress),
+    Spend(DbcAddress),
 }
 
 impl DataAddress {
@@ -34,8 +35,13 @@ impl DataAddress {
         match self {
             Self::Chunk(address) => address.name(),
             Self::Register(address) => address.name(),
-            Self::Spentbook(address) => address.name(),
+            Self::Spend(address) => address.name(),
         }
+    }
+
+    ///
+    pub fn chunk(name: XorName) -> Self {
+        Self::Chunk(ChunkAddress::new(name))
     }
 
     ///
@@ -44,7 +50,7 @@ impl DataAddress {
     }
 
     ///
-    pub fn chunk(name: XorName) -> Self {
-        Self::Chunk(ChunkAddress::new(name))
+    pub fn spend(dbc_id: DbcId) -> Self {
+        Self::Spend(DbcAddress::new(dbc_name(&dbc_id)))
     }
 }

--- a/safenode/src/protocol/types/error.rs
+++ b/safenode/src/protocol/types/error.rs
@@ -7,12 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    address::{ChunkAddress, RegisterAddress},
+    address::{ChunkAddress, DbcAddress, RegisterAddress},
     authority::PublicKey,
     register::{EntryHash, User},
 };
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, result};
+use sn_dbc::SignedSpend;
+use std::{collections::BTreeSet, fmt::Debug, result};
 use thiserror::Error;
 
 /// A specialised `Result` type for types crate.
@@ -34,6 +35,12 @@ pub enum Error {
     /// Register not found.
     #[error("Register not found: {0:?}")]
     RegisterNotFound(RegisterAddress),
+    /// Spend not found.
+    #[error("Spend not found: {0:?}")]
+    SpendNotFound(DbcAddress),
+    /// A double spend attempt was detected.
+    #[error("A double spend attempt was detected. Set of mismatching spends: {0:?}")]
+    DoubleSpendAttempt(BTreeSet<SignedSpend>),
     /// Unexpected responses.
     #[error("Unexpected responses")]
     UnexpectedResponses,

--- a/safenode/src/protocol/types/error.rs
+++ b/safenode/src/protocol/types/error.rs
@@ -43,9 +43,9 @@ pub enum Error {
     DoubleSpendAttempt(BTreeSet<SignedSpend>),
     /// A parent spend of a requested spend could not be confirmed as valid.
     #[error(
-        "A parent spend of a requested spend could not be confirmed as valid. Parent dbc {0:?}"
+        "A parent tx of a requested spend could not be confirmed as valid. All invalid parents' addresses {0:?}"
     )]
-    InvalidSpendParent(DbcAddress),
+    InvalidSpendParentTx(BTreeSet<DbcAddress>),
     /// Unexpected responses.
     #[error("Unexpected responses")]
     UnexpectedResponses,

--- a/safenode/src/protocol/types/error.rs
+++ b/safenode/src/protocol/types/error.rs
@@ -41,6 +41,11 @@ pub enum Error {
     /// A double spend attempt was detected.
     #[error("A double spend attempt was detected. Set of mismatching spends: {0:?}")]
     DoubleSpendAttempt(BTreeSet<SignedSpend>),
+    /// A parent spend of a requested spend could not be confirmed as valid.
+    #[error(
+        "A parent spend of a requested spend could not be confirmed as valid. Parent dbc {0:?}"
+    )]
+    InvalidSpendParent(DbcAddress),
     /// Unexpected responses.
     #[error("Unexpected responses")]
     UnexpectedResponses,

--- a/safenode/src/protocol/types/mod.rs
+++ b/safenode/src/protocol/types/mod.rs
@@ -6,13 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-/// Addresses types
+/// Address types
 pub mod address;
-/// Data/content Authority types
+/// Data/content Authority types.
 pub mod authority;
-/// Chunk type
+/// Chunk type.
 pub mod chunk;
-/// Errors
+/// Errors.
 pub mod error;
-/// Register type
+/// Register type.
 pub mod register;
+/// Spend type.
+pub mod spend;

--- a/safenode/src/protocol/types/register/mod.rs
+++ b/safenode/src/protocol/types/register/mod.rs
@@ -171,13 +171,14 @@ impl Register {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{
+    use crate::protocol::types::{
         error::{Error, Result},
         register::{
             Entry, EntryHash, Permissions, Policy, Register, RegisterAddress, RegisterOp, User,
             MAX_REG_NUM_ENTRIES,
         },
     };
+
     use bls::SecretKey;
     use eyre::Context;
     use proptest::prelude::*;

--- a/safenode/src/protocol/types/spend.rs
+++ b/safenode/src/protocol/types/spend.rs
@@ -1,0 +1,50 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::address::{dbc_name, DbcAddress};
+
+use sn_dbc::{DbcId, SignedSpend};
+
+use serde::{Deserialize, Serialize};
+use xor_name::XorName;
+
+/// An immutable Spend of a Dbc, meaning that the
+/// value of it has been transferred to other Dbc(s).
+#[derive(Hash, Eq, PartialEq, Clone, custom_debug::Debug, Serialize, Deserialize)]
+pub struct Spend {
+    /// Network address of a Dbc, where its spend will be recorded.
+    address: DbcAddress,
+    /// Contained `SignedSpend`.
+    #[debug(skip)]
+    signed_spend: SignedSpend,
+}
+
+impl Spend {
+    /// Create a new instance of `Spend`.
+    pub fn new(dbc_id: DbcId, signed_spend: SignedSpend) -> Self {
+        Self {
+            address: DbcAddress::new(dbc_name(&dbc_id)),
+            signed_spend,
+        }
+    }
+
+    /// Return the id.
+    pub fn id(&self) -> &XorName {
+        self.address.name()
+    }
+
+    /// Return the address.
+    pub fn address(&self) -> &DbcAddress {
+        &self.address
+    }
+
+    /// Return the value.
+    pub fn signed_spend(&self) -> &SignedSpend {
+        &self.signed_spend
+    }
+}

--- a/safenode/src/storage/registers.rs
+++ b/safenode/src/storage/registers.rs
@@ -99,7 +99,6 @@ impl RegisterStorage {
     }
 
     /// --- Reading ---
-
     pub(super) async fn read(&self, read: &RegisterQuery, requester: User) -> QueryResponse {
         trace!("Reading register: {:?}", read.dst());
         use RegisterQuery::*;

--- a/safenode/src/storage/spends.rs
+++ b/safenode/src/storage/spends.rs
@@ -1,0 +1,200 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::protocol::types::{
+    address::DbcAddress,
+    error::{Error, Result},
+};
+
+use sn_dbc::{DbcId, SignedSpend};
+
+use clru::CLruCache;
+use std::{
+    collections::BTreeSet,
+    fmt::{self, Display, Formatter},
+    num::NonZeroUsize,
+    sync::Arc,
+};
+use tokio::sync::RwLock;
+use tracing::trace;
+use xor_name::XorName;
+
+/// We will store at most 50MiB of data in a SpendStorage instance.
+const SPENDS_CACHE_SIZE: usize = 45 * 1024 * 1024;
+const DOUBLE_SPENDS_CACHE_SIZE: usize = 5 * 1024 * 1024;
+
+/// For every DbcId, there is a collection of transactions.
+/// Every transaction has a set of peers who reported that they hold this transaction.
+/// At a higher level, a peer will store a spend to `valid_spends` if the dbc checks out as valid, _and_ the parents of the dbc checks out as valid.
+/// A peer will move a spend from `valid_spends` to `double_spends` if it receives another tx id for the same dbc id.
+/// A peer will never again store such a spend to `valid_spends`.
+type ValidSpends<V> = Arc<RwLock<CLruCache<DbcAddress, V>>>;
+type DoubleSpends<V> = Arc<RwLock<CLruCache<DbcAddress, BTreeSet<V>>>>;
+
+/// Storage of Dbc spends.
+#[derive(Clone, Debug)]
+pub(super) struct SpendStorage {
+    valid_spends: ValidSpends<SignedSpend>,
+    double_spends: DoubleSpends<SignedSpend>,
+}
+
+impl SpendStorage {
+    // Read Spend from local store.
+    pub(super) async fn get(&self, address: &DbcAddress) -> Result<SignedSpend> {
+        trace!("Getting Spend: {address:?}");
+        if let Some(spend) = self.valid_spends.read().await.peek(address) {
+            Ok(spend.clone())
+        } else {
+            Err(Error::SpendNotFound(*address))
+        }
+    }
+
+    /// We need to check that the parent is spent before
+    /// we try add here.
+    /// If a double spend attempt is detected, a `DoubleSpendAttempt` error
+    /// will be returned including all the `SignedSpends`, for
+    /// broadcasting to the other nodes.
+    pub(super) async fn try_add(&self, signed_spend: &SignedSpend) -> Result<()> {
+        // We want to return Result<(SignedSpend)> here, so that this node
+        let address = dbc_address(signed_spend.dbc_id());
+        // I was thinking that we perhaps can't hold a reference into the cache, as it could
+        // deadlock if we want to write further down? Not sure if that would happen. To be confirmed.
+        let mut double_spends_of_this_dbc = match self.double_spends.read().await.peek(&address) {
+            Some(set) => set.clone(),
+            None => BTreeSet::new(),
+        };
+
+        // Important: The spend id is from the spend hash. This makes sure
+        // that a spend is compared based on both the `DbcTransaction` and the `DbcReason` being equal.
+        let spend_id = get_spend_id(signed_spend.spend.hash());
+        let tamper_attempted = match self.valid_spends.read().await.peek(&address) {
+            Some(existing) => spend_id != get_spend_id(existing.spend.hash()),
+            None => false,
+        };
+        let tamper_previously_detected = double_spends_of_this_dbc
+            .iter()
+            .any(|s| s.dbc_id() == signed_spend.dbc_id());
+
+        if tamper_attempted || tamper_previously_detected {
+            // The data argument, being a SignedSpend, I don't get where it comes from.
+            let _replaced = self.double_spends.write().await.put_or_modify(
+                address,
+                |_addr, _proof| {
+                    let _ = double_spends_of_this_dbc.insert(signed_spend.clone());
+                    double_spends_of_this_dbc.clone()
+                },
+                |_a, map, _c| {
+                    let _ = map.insert(signed_spend.clone());
+                },
+                signed_spend.clone(),
+            );
+
+            if tamper_attempted {
+                // The spend is now permanently removed from the valid spends.
+                self.valid_spends
+                    .write()
+                    .await
+                    .retain(|key, _| key != &address);
+            }
+
+            return Err(Error::DoubleSpendAttempt(double_spends_of_this_dbc));
+        }
+
+        if self.valid_spends.read().await.peek(&address).is_none() {
+            // will it deadlock here?
+            let _ = self
+                .valid_spends
+                .write()
+                .await
+                .put(address, signed_spend.clone());
+        }
+
+        Ok(())
+        // Ok(spend.clone())
+    }
+
+    /// When data is replicated to a new peer,
+    /// it may contain double spends, and thus we need to add that here,
+    /// so that we in the future can serve this info to Clients.
+    #[allow(unused)] // to be used when we replicate data between nodes
+    pub(super) async fn try_add_doubles(
+        &self,
+        received_double_spends: &BTreeSet<SignedSpend>,
+    ) -> Result<()> {
+        // Since the SignedSpends are in a BTreeSet, we know that they are different.
+        // We will also check that we have more than one SignedSpend for each DbcId,
+        // which would prove to us that there was a double spend attempt for that Dbc.
+        let unique_ids: BTreeSet<_> = received_double_spends.iter().map(|s| s.dbc_id()).collect();
+
+        for dbc_id in unique_ids {
+            let copies: BTreeSet<_> = received_double_spends
+                .iter()
+                .map(|s| dbc_id == s.dbc_id())
+                .collect();
+            if copies.len() <= 1 {
+                // We only add these to double_spends if there are two or more of them,
+                // as otherwise we can't actually tell that it's a double spend attempt.
+                continue;
+            }
+            let address = dbc_address(dbc_id);
+            let _replaced = self.double_spends.write().await.put_or_modify(
+                address,
+                |_addr, double_spends| double_spends,
+                |_a, map, double_spends| {
+                    map.extend(double_spends);
+                },
+                received_double_spends.clone(),
+            );
+            // The spend is now permanently removed from the valid spends.
+            self.valid_spends
+                .write()
+                .await
+                .retain(|key, _| key != &address);
+        }
+
+        Ok(())
+    }
+}
+
+impl Display for SpendStorage {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "SpendStorage")
+    }
+}
+
+impl Default for SpendStorage {
+    fn default() -> Self {
+        let spend_capacity =
+            NonZeroUsize::new(SPENDS_CACHE_SIZE).expect("Failed to create in-memory Spend cache.");
+        let double_spend_capacity = NonZeroUsize::new(DOUBLE_SPENDS_CACHE_SIZE)
+            .expect("Failed to create in-memory DoubleSpend cache");
+        Self {
+            valid_spends: Arc::new(RwLock::new(CLruCache::new(spend_capacity))),
+            double_spends: Arc::new(RwLock::new(CLruCache::new(double_spend_capacity))),
+        }
+    }
+}
+
+/// Still thinking of best location for this.
+/// Wanted to make the DbcAddress take a dbc id actually..
+fn dbc_address(dbc_id: &DbcId) -> DbcAddress {
+    DbcAddress::new(get_dbc_name(dbc_id))
+}
+
+/// Still thinking of best location for this.
+/// Wanted to make the DbcAddress take a dbc id actually..
+fn get_dbc_name(dbc_id: &DbcId) -> XorName {
+    XorName::from_content(&dbc_id.to_bytes())
+}
+
+/// Still thinking of best location for this.
+/// Wanted to make the DbcAddress take a dbc id actually..
+fn get_spend_id(content_hash: sn_dbc::Hash) -> XorName {
+    // TODO: XorName(*content_hash.slice())
+    XorName::from_content(content_hash.as_ref())
+}


### PR DESCRIPTION
The close group of a received `Spend`, calls the close groups of the parents of that `Spend`, and check that the returned parent `Spends` are valid. That is a prerequisite for storing the `Spend` sent by a client. (If any of them are not valid, that shall be communicated to those close groups.)

The Spend is then put in to `SpendStorage`, which validates them before storing them as a `valid Spend`. If a `double spend` is attempted, the `Spend` is permanently marked as `unspendable` (this shall also be communicated to the rest of the peers).
A peer will thus make sure to only return a `Spend` if it has been considered **valid** by the peer.

After this `Spend` has been stored, it is up to the client to query all
close nodes and verify that it is recognised by enough nodes. 
That then makes the spend valid.

- **NB 1**: More validations might be needed.
- **NB 2**: There are stubs to broadcast
a) Invalid parent spends, to each of their close groups.
b) Attempted double spends to our peers (i.e. this close group, responsible for this spend).
And so the sending, and handling of those msgs at recipient peers, is still to be done.