### PR TITLE
feat: random query on peer added

### DIFF
--- a/safenode/src/bin/kadclient.rs
+++ b/safenode/src/bin/kadclient.rs
@@ -24,7 +24,7 @@ use safenode::{
         },
     },
 };
-use std::{collections::BTreeSet, fs, path::PathBuf, thread, time};
+use std::{collections::BTreeSet, fs, path::PathBuf};
 use tracing::{info, warn};
 use walkdir::WalkDir;
 use xor_name::XorName;
@@ -53,6 +53,10 @@ async fn main() -> Result<()> {
                 let chunk = Chunk::new(Bytes::from(file));
                 let xor_name = *chunk.name();
                 info!(
+                    "Storing chunk {:?} with xorname: {xor_name:x}",
+                    entry.file_name()
+                );
+                println!(
                     "Storing chunk {:?} with xorname: {xor_name:x}",
                     entry.file_name()
                 );
@@ -151,10 +155,7 @@ async fn main() -> Result<()> {
         };
     }
 
-    // Keep the client running.
-    loop {
-        thread::sleep(time::Duration::from_millis(100));
-    }
+    Ok(())
 }
 
 #[derive(Parser, Debug)]

--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -37,6 +37,7 @@ impl Client {
     pub fn new() -> Result<Self> {
         info!("Starting Kad swarm in client mode...");
         let (network, mut network_event_receiver, swarm_driver) = SwarmDriver::new_client()?;
+        info!("Client constructed network and swarm_driver");
         let events_channel = ClientEventsChannel::default();
         let client = Self {
             network,
@@ -47,6 +48,7 @@ impl Client {
         let _swarm_driver = spawn(swarm_driver.run());
         let _event_handler = spawn(async move {
             loop {
+                info!("Client waiting for a network event");
                 let event = match network_event_receiver.recv().await {
                     Some(event) => event,
                     None => {
@@ -54,6 +56,7 @@ impl Client {
                         continue;
                     }
                 };
+                trace!("Client recevied a network event {event:?}");
                 if let Err(err) = client_clone.handle_network_event(event) {
                     warn!("Error handling network event: {err}");
                 }

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -80,6 +80,7 @@ impl SwarmDriver {
     pub fn new() -> Result<(Network, mpsc::Receiver<NetworkEvent>, SwarmDriver)> {
         let mut cfg = KademliaConfig::default();
         let _ = cfg.set_query_timeout(Duration::from_secs(5 * 60));
+        let _ = cfg.set_connection_idle_timeout(Duration::from_secs(10 * 60));
 
         let request_response = request_response::Behaviour::new(
             MsgCodec(),

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -27,6 +27,7 @@ use futures::future::select_all;
 use libp2p::{request_response::ResponseChannel, PeerId};
 use std::{collections::BTreeSet, time::Duration};
 use tokio::task::spawn;
+use xor_name::XorName;
 
 impl Node {
     /// Write to storage.
@@ -89,6 +90,17 @@ impl Node {
             }
             NetworkEvent::PeerAdded => {
                 self.events_channel.broadcast(NodeEvent::ConnectedToNetwork);
+                let target = {
+                    let mut rng = rand::thread_rng();
+                    XorName::random(&mut rng)
+                };
+
+                let network = self.network.clone();
+                let _handle = spawn(async move {
+                    trace!("Getting closest peers for target {target:?}");
+                    let result = network.node_get_closest_peers(target).await;
+                    trace!("For target {target:?}, get closest peers {result:?}");
+                });
             }
         }
 


### PR DESCRIPTION
Fire a random get_closest_peers query when received a PeerAdded event.
This is necessary to allow nodes get a full knowledge of the network.
And allows the client upload chunk and get chunk back properly.