### PR TITLE
feat: implement wallet

### DIFF
--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -34,7 +34,7 @@ rmp-serde = "1.1.1"
 rayon = "~1.5.1"
 self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "16.0.0", features = ["serdes"] }
+sn_dbc = { git = "https://github.com/oetyng/sn_dbc", branch = "refactor-have-dbcs-take-derived-key", features = ["serdes"] }
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }

--- a/safenode/src/protocol/types/dbc_genesis.rs
+++ b/safenode/src/protocol/types/dbc_genesis.rs
@@ -1,0 +1,92 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use sn_dbc::{
+    rng, Dbc, DbcTransaction, Error as DbcError, Hash, InputHistory, MainKey, RevealedAmount,
+    RevealedInput, Token, TransactionBuilder,
+};
+
+use std::{fmt::Debug, result};
+use thiserror::Error;
+
+/// Amount of tokens to be owned by the Genesis DBC.
+/// At the inception of the Network a total supply of 4,294,967,295 whole tokens will be created.
+/// Each whole token can be subdivided 10^9 times,
+/// thus creating a total of 4,294,967,295,000,000,000 available units.
+pub const GENESIS_DBC_AMOUNT: u64 = u32::MAX as u64 * u64::pow(10, 9);
+
+/// A specialised `Result` type for types crate.
+pub type Result<T> = result::Result<T, Error>;
+
+/// Main error type for the crate.
+#[derive(Error, Debug, Clone)]
+// #[non_exhaustive]
+#[non_exhaustive]
+pub enum Error {
+    /// Error occurred when minting the Genesis DBC.
+    #[error("Genesis DBC error:: {0}")]
+    GenesisDbcError(String),
+    /// FailedToParseReason
+    #[error("Failed to parse reason: {0}")]
+    FailedToParseReason(#[from] DbcError),
+}
+
+/// Generate the genesis DBC.
+///
+/// Requires the initial section key to sign the share and a different secret key for the DBC.
+///
+/// The genesis DBC will be created using a different key from the initial section key. This is
+/// because the genesis DBC, along with its secret key, will be publicly available for auditing
+/// purposes. It needs to be a set rather than just a key because a spent proof share gets
+/// generated, which requires a key set. We can't use the same key for the genesis DBC and section
+/// because if the genesis DBC is publicly available, the secret key could be used to create a bad
+/// section that would be accepted by the network.
+#[allow(clippy::result_large_err)]
+pub fn create_genesis_dbc(genesis_main_key: &MainKey) -> Result<Dbc> {
+    let rng = &mut rng::thread_rng();
+
+    let dbc_id_src = genesis_main_key.random_dbc_id_src(rng);
+    let derived_key = genesis_main_key.derive_key(&dbc_id_src.derivation_index);
+    let revealed_amount = RevealedAmount::from_amount(GENESIS_DBC_AMOUNT, rng);
+
+    // Use the same key as the input and output of Genesis Tx.
+    // The src tx is empty as this is the first DBC.
+    let genesis_input = InputHistory {
+        input: RevealedInput::new(derived_key, revealed_amount),
+        input_src_tx: DbcTransaction {
+            inputs: vec![],
+            outputs: vec![],
+        },
+    };
+
+    let dbc_builder = TransactionBuilder::default()
+        .add_input(genesis_input)
+        .add_output(Token::from_nano(GENESIS_DBC_AMOUNT), dbc_id_src)
+        .build(Hash::default(), rng::thread_rng())
+        .map_err(|err| {
+            Error::GenesisDbcError(format!(
+                "Failed to build the DBC transaction for genesis DBC: {err}",
+            ))
+        })?;
+
+    // build the output DBCs
+    let output_dbcs = dbc_builder.build_without_verifying().map_err(|err| {
+        Error::GenesisDbcError(format!(
+            "DBC builder failed to create output genesis DBC: {err}",
+        ))
+    })?;
+
+    // just one output DBC is expected which is the genesis DBC
+    let (genesis_dbc, _) = output_dbcs.into_iter().next().ok_or_else(|| {
+        Error::GenesisDbcError(
+            "DBC builder (unexpectedly) contains an empty set of outputs.".to_string(),
+        )
+    })?;
+
+    Ok(genesis_dbc)
+}

--- a/safenode/src/protocol/types/dbc_genesis.rs
+++ b/safenode/src/protocol/types/dbc_genesis.rs
@@ -91,14 +91,6 @@ pub fn create_genesis_dbc(genesis_main_key: &MainKey) -> GenesisResult<Dbc> {
     Ok(genesis_dbc)
 }
 
-// Copyright 2023 MaidSafe.net limited.
-//
-// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
-// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
-// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied. Please review the Licences for the specific language governing
-// permissions and limitations relating to use of the SAFE Network Software.
-
 pub(super) type Result<T> = std::result::Result<T, Error>;
 
 /// Error type returned by the API
@@ -136,28 +128,11 @@ pub fn send_tokens(
     dbcs: Vec<(Dbc, DerivedKey)>,
     recipients: Vec<(Token, DbcIdSource)>,
     change_to: PublicAddress,
-    // reason: DbcReason,
-    // priority: SpendPriority,
 ) -> Result<ReissueOutputs> {
-    // let mut attempts = 0;
-    // let mut max_required = Token::zero();
-
     // We need to select the necessary number of dbcs from those that we were passed.
     // This will also account for any fees.
     let reissue_inputs = select_inputs(dbcs, recipients, change_to)?;
-
     reissue(reissue_inputs)
-    // // then we can reissue
-    // match reissue(reissue_inputs).await {
-    //     Ok(outputs) => return Ok(outputs),
-    //     Err(Error::FeeTooLow(required)) => {
-    //         max_required = required;
-    //         attempts += 1;
-    //     }
-    //     error => return error,
-    // }
-
-    // Err(Error::FeeTooLow(max_required))
 }
 
 /// The input dbcs will be spent on the network, and the resulting
@@ -173,10 +148,6 @@ fn reissue(
         input_dbcs,
         outputs,
         change: (change, change_to),
-        // #[cfg(not(feature = "data-network"))]
-        // fees_paid,
-        // #[cfg(not(feature = "data-network"))]
-        // all_fee_cipher_params,
     } = reissue_inputs;
 
     let mut inputs = vec![];
@@ -206,62 +177,13 @@ fn reissue(
         tx_builder = tx_builder.add_output(change, dbc_id_src);
     }
 
-    // let inputs_spent_proofs: BTreeSet<SpentProof> = input_dbcs
-    //     .iter()
-    //     .flat_map(|dbc| dbc.inputs_spent_proofs.clone())
-    //     .collect();
-    // let inputs_spent_transactions: BTreeSet<DbcTransaction> = input_dbcs
-    //     .iter()
-    //     .flat_map(|dbc| dbc.inputs_spent_transactions.clone())
-    //     .collect();
-
     // Finalize the tx builder to get the dbc builder.
     let dbc_builder = tx_builder
         .build(Hash::default(), &mut rng)
         .map_err(Error::DbcError)?;
 
-    // // Get fee outputs to generate the fee ciphers.
-    // #[cfg(not(feature = "data-network"))]
-    // let outputs = dbc_builder
-    //     .revealed_outputs
-    //     .iter()
-    //     .map(|output| (output.public_key, output.revealed_amount))
-    //     .collect();
-
     let inputs = dbc_builder.signed_spends();
     let spent_dbcs = inputs.iter().map(|spent| spent.dbc_id()).cloned().collect();
-
-    // // Spend all the input DBCs, collecting the spent proof shares for each of them
-    // for (public_key, tx) in inputs {
-    //     // // Generate the fee ciphers.
-    //     // #[cfg(not(feature = "data-network"))]
-    //     // let input_fee_ciphers = {
-    //     //     let fee_cipher_params = all_fee_cipher_params
-    //     //         .get(&public_key)
-    //     //         .ok_or(Error::DbcReissueError("Missing fee!".to_string()))?;
-    //     //     fee_ciphers(&outputs, fee_cipher_params)?
-    //     // };
-
-    //     let tx_hash = Hash::from(tx.hash());
-    //     // TODO: spend DBCs concurrently spawning tasks
-    //     let mut attempts = 0;
-    //     loop {
-    //         attempts += 1;
-    //         client
-    //             .spend_dbc(
-    //                 public_key,
-    //                 tx.clone(),
-    //                 reason,
-    //                 inputs_spent_proofs.clone(),
-    //                 inputs_spent_transactions.clone(),
-    //                 #[cfg(not(feature = "data-network"))]
-    //                 input_fee_ciphers.clone(),
-    //             )
-    //             .await?;
-
-    //         let signed_spend = client.get_signed_spend(public_key).await?;
-    //     }
-    // }
 
     // Perform verifications of input TX and spentproofs,
     // as well as building the output DBCs.
@@ -281,8 +203,6 @@ fn reissue(
         outputs: output_dbcs,
         change: change_dbc,
         spent_dbcs,
-        // #[cfg(not(feature = "data-network"))]
-        // fees_paid,
     })
 }
 
@@ -311,105 +231,9 @@ pub(crate) fn select_inputs(
         })?;
 
     let mut change_amount = total_output_amount;
-    // let mut rng = rng::thread_rng();
-    // #[cfg(not(feature = "data-network"))]
-    // let mut all_fee_cipher_params = BTreeMap::new();
-    // #[cfg(not(feature = "data-network"))]
-    // let mut fees_paid = Token::zero();
 
     for (dbc, derived_key) in inputs {
-        // let revealed_amount = match dbc.revealed_amount(derived_key).map_err(Error::DbcError) {
-        //     Ok(revealed) => revealed,
-        //     Err(error) => {
-        //         error!(
-        //             "Could not get the amount from dbc {:?}, wrong derived key used! {error}",
-        //             dbc.id(),
-        //         );
-        //         continue;
-        //     }
-        // };
-
         let input_key = dbc.id();
-
-        #[cfg(not(feature = "data-network"))]
-        {
-            // // ------------ fee part start ----------------
-            // #[cfg(not(feature = "data-network"))]
-            // let fee_per_input = {
-            //     // Each section will have elder_count() instances to pay individually (for now, later they will be more).
-            //     let elder_fees = match client.get_section_fees(input_key, priority).await {
-            //         Ok(fees) => fees,
-            //         Err(error) => {
-            //             error!("Could not get fees for input dbc: {input_key:?}: {error}");
-            //             continue;
-            //         }
-            //     };
-            //     let num_responses = elder_fees.len();
-            //     let required_responses = supermajority(elder_count());
-            //     if required_responses > num_responses {
-            //         warn!("Not enough elders contacted for the section to spend the input. Got: {num_responses}, needed: {required_responses}");
-            //         continue;
-            //     }
-
-            //     // Fees that were not encrypted to us.
-            //     let mut invalid_fees = BTreeSet::new();
-            //     // As the Elders encrypt the amount to our public key, we need to decrypt it.
-            //     let mut decrypted_elder_fees = vec![];
-
-            //     for (elder, fee) in elder_fees {
-            //         match fee.content.decrypt_amount(&revealed_bearer.secret_key) {
-            //             Ok(amount) => decrypted_elder_fees.push(((elder, fee), amount)),
-            //             Err(error) => {
-            //                 error!("Decrypting the fee content from {elder} failed! {error}");
-            //                 let _ = invalid_fees.insert(fee.content.elder_reward_key);
-            //             }
-            //         }
-            //     }
-
-            //     let max_invalid_fees = elder_count() - required_responses;
-            //     if invalid_fees.len() > max_invalid_fees {
-            //         let valid_responses = num_responses - invalid_fees.len();
-            //         warn!("Not enough valid fees received from the section to spend the input. Found: {valid_responses}, needed: {required_responses}", );
-            //         continue;
-            //     }
-
-            //     // Total fee paid to all recipients in the section for this input.
-            //     let fee_per_input = decrypted_elder_fees
-            //         .iter()
-            //         .fold(Some(Token::zero()), |total, (_, fee)| {
-            //             total.and_then(|t| t.checked_add(*fee))
-            //         })
-            //         .ok_or_else(|| Error::DbcReissueError(
-            //             "Overflow occurred while summing the individual Elder's fees in order to calculate the total amount for the output DBCs."
-            //                 .to_string(),
-            //         ))?;
-
-            //     let mut fee_cipher_params = BTreeMap::new();
-
-            //     // Add elders to outputs and generate their fee ciphers.
-            //     decrypted_elder_fees
-            //         .iter()
-            //         .for_each(|((elder, required_fee), fee)| {
-            //             let owner = Owner::from(required_fee.content.elder_reward_key);
-            //             let owner_once = OwnerOnce::from_owner_base(owner, &mut rng);
-            //             outputs.push((*fee, owner_once.clone()));
-
-            //             let _ =
-            //                 fee_cipher_params.insert(elder.name(), (required_fee.clone(), owner_once));
-            //         });
-
-            //     let _ = all_fee_cipher_params.insert(input_key, fee_cipher_params);
-
-            //     fees_paid = fees_paid.checked_add(fee_per_input).ok_or_else(|| {
-            //         Error::DbcReissueError(
-            //             "Overflow occurred while summing all the input fees.".to_string(),
-            //         )
-            //     })?;
-
-            //     fee_per_input
-            // };
-            // // ---------------- fee part end ----------------
-        }
 
         let dbc_balance = match dbc.revealed_amount(&derived_key) {
             Ok(revealed_amount) => Token::from_nano(revealed_amount.value()),
@@ -430,26 +254,6 @@ pub(crate) fn select_inputs(
                     .to_string(),
             )
             })?;
-
-        #[cfg(not(feature = "data-network"))]
-        {
-            // // Output amount now increases a bit, as we have to cover the fee as well..
-            // total_output_amount = total_output_amount.checked_add(fee_per_input)
-            // .ok_or_else(|| {
-            //     Error::DbcReissueError(
-            //     "Overflow occurred while adding mint fee in order to calculate the total amount for the output DBCs."
-            //         .to_string(),
-            // )
-            // })?;
-            // // ..and so does `change_amount` (that we subtract from to know if we've covered `total_output_amount`).
-            // change_amount = change_amount.checked_add(fee_per_input)
-            // .ok_or_else(|| {
-            //     Error::DbcReissueError(
-            //     "Overflow occurred while adding mint fee in order to calculate the total amount for the output DBCs."
-            //         .to_string(),
-            // )
-            // })?;
-        }
 
         // If we've already combined input DBCs for the total output amount, then stop.
         match change_amount.checked_sub(dbc_balance) {
@@ -473,10 +277,6 @@ pub(crate) fn select_inputs(
         input_dbcs,
         outputs,
         change: (change_amount, change_to),
-        // #[cfg(not(feature = "data-network"))]
-        // fees_paid,
-        // #[cfg(not(feature = "data-network"))]
-        // all_fee_cipher_params,
     })
 }
 
@@ -489,8 +289,6 @@ fn verify_amounts(total_input_amount: Token, total_output_amount: Token) -> Resu
     Ok(())
 }
 
-// type ReissueCiphers = BTreeMap<PublicKey, BTreeMap<XorName, (RequiredFee, OwnerOnce)>>;
-
 ///
 #[derive(Debug)]
 pub struct ReissueInputs {
@@ -500,14 +298,6 @@ pub struct ReissueInputs {
     pub outputs: Vec<(Token, DbcIdSource)>,
     /// Any surplus amount after spending the necessary input dbcs.
     pub change: (Token, PublicAddress),
-    // /// Total fees to pay for spending the inputs.
-    // #[cfg(not(feature = "data-network"))]
-    // pub fees_paid: Token,
-    // /// This is the set of input dbc keys, each having a set of
-    // /// Elder names and their respective fee ciphers.
-    // /// Sent together with spends, so that Elders can verify their fee payments.
-    // #[cfg(not(feature = "data-network"))]
-    // pub all_fee_cipher_params: ReissueCiphers,
 }
 
 /// The results of reissuing dbcs.
@@ -519,7 +309,4 @@ pub struct ReissueOutputs {
     pub change: Option<Dbc>,
     /// The dbcs we spent when reissuing.
     pub spent_dbcs: BTreeSet<DbcId>,
-    // /// Total fees to paid for this tx.
-    // #[cfg(not(feature = "data-network"))]
-    // pub fees_paid: Token,
 }

--- a/safenode/src/protocol/types/dbc_genesis.rs
+++ b/safenode/src/protocol/types/dbc_genesis.rs
@@ -7,11 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use sn_dbc::{
-    rng, Dbc, DbcTransaction, Error as DbcError, Hash, InputHistory, MainKey, RevealedAmount,
-    RevealedInput, Token, TransactionBuilder,
+    rng, Dbc, DbcId, DbcIdSource, DbcTransaction, DerivedKey, Error as DbcError, Hash,
+    InputHistory, MainKey, PublicAddress, RevealedAmount, RevealedInput, Token, TransactionBuilder,
 };
 
-use std::{fmt::Debug, result};
+use std::{collections::BTreeSet, fmt::Debug, result};
 use thiserror::Error;
 
 /// Amount of tokens to be owned by the Genesis DBC.
@@ -21,13 +21,13 @@ use thiserror::Error;
 pub const GENESIS_DBC_AMOUNT: u64 = u32::MAX as u64 * u64::pow(10, 9);
 
 /// A specialised `Result` type for types crate.
-pub type Result<T> = result::Result<T, Error>;
+pub type GenesisResult<T> = result::Result<T, GenesisError>;
 
 /// Main error type for the crate.
 #[derive(Error, Debug, Clone)]
 // #[non_exhaustive]
 #[non_exhaustive]
-pub enum Error {
+pub enum GenesisError {
     /// Error occurred when minting the Genesis DBC.
     #[error("Genesis DBC error:: {0}")]
     GenesisDbcError(String),
@@ -47,7 +47,7 @@ pub enum Error {
 /// because if the genesis DBC is publicly available, the secret key could be used to create a bad
 /// section that would be accepted by the network.
 #[allow(clippy::result_large_err)]
-pub fn create_genesis_dbc(genesis_main_key: &MainKey) -> Result<Dbc> {
+pub fn create_genesis_dbc(genesis_main_key: &MainKey) -> GenesisResult<Dbc> {
     let rng = &mut rng::thread_rng();
 
     let dbc_id_src = genesis_main_key.random_dbc_id_src(rng);
@@ -69,24 +69,457 @@ pub fn create_genesis_dbc(genesis_main_key: &MainKey) -> Result<Dbc> {
         .add_output(Token::from_nano(GENESIS_DBC_AMOUNT), dbc_id_src)
         .build(Hash::default(), rng::thread_rng())
         .map_err(|err| {
-            Error::GenesisDbcError(format!(
+            GenesisError::GenesisDbcError(format!(
                 "Failed to build the DBC transaction for genesis DBC: {err}",
             ))
         })?;
 
     // build the output DBCs
     let output_dbcs = dbc_builder.build_without_verifying().map_err(|err| {
-        Error::GenesisDbcError(format!(
+        GenesisError::GenesisDbcError(format!(
             "DBC builder failed to create output genesis DBC: {err}",
         ))
     })?;
 
     // just one output DBC is expected which is the genesis DBC
     let (genesis_dbc, _) = output_dbcs.into_iter().next().ok_or_else(|| {
-        Error::GenesisDbcError(
+        GenesisError::GenesisDbcError(
             "DBC builder (unexpectedly) contains an empty set of outputs.".to_string(),
         )
     })?;
 
     Ok(genesis_dbc)
+}
+
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+pub(super) type Result<T> = std::result::Result<T, Error>;
+
+/// Error type returned by the API
+#[derive(Debug, Error)]
+#[allow(clippy::large_enum_variant)]
+#[non_exhaustive]
+pub enum Error {
+    /// Not enough balance to perform a transaction
+    #[error("Not enough balance: {0}")]
+    NotEnoughBalance(String),
+    /// Not enough was paid in fees for the Elders to process the spend.
+    #[error("Too low amount for the transfer. Highest required fee: {0:?}.")]
+    FeeTooLow(Token),
+    /// DbcError
+    #[error("DbcError: {0}")]
+    DbcError(#[from] DbcError),
+    /// DbcReissueError
+    #[error("DbcReissueError: {0}")]
+    DbcReissueError(String),
+    /// Verification of DBC validly signed by a known section failed
+    #[error("DBC validity verification failed: {0}")]
+    DbcVerificationFailed(String),
+}
+
+/// Send the tokens to the specified destination keys, using the provided dbcs.
+/// The new dbcs that are created, one per specified destination, will have the
+/// unique id which is the public key of the `OwnerOnce` instances provided.
+///
+/// Transfer fees will be paid if not in data-network.
+/// The input dbcs will be spent on the network, and the resulting
+/// dbcs (and change dbc if any) are returned.
+/// NB: We are skipping the DbcReason arg for now. It can be added later.
+#[allow(clippy::result_large_err)]
+pub fn send_tokens(
+    dbcs: Vec<(Dbc, DerivedKey)>,
+    recipients: Vec<(Token, DbcIdSource)>,
+    change_to: PublicAddress,
+    // reason: DbcReason,
+    // priority: SpendPriority,
+) -> Result<ReissueOutputs> {
+    // let mut attempts = 0;
+    // let mut max_required = Token::zero();
+
+    // We need to select the necessary number of dbcs from those that we were passed.
+    // This will also account for any fees.
+    let reissue_inputs = select_inputs(dbcs, recipients, change_to)?;
+
+    reissue(reissue_inputs)
+    // // then we can reissue
+    // match reissue(reissue_inputs).await {
+    //     Ok(outputs) => return Ok(outputs),
+    //     Err(Error::FeeTooLow(required)) => {
+    //         max_required = required;
+    //         attempts += 1;
+    //     }
+    //     error => return error,
+    // }
+
+    // Err(Error::FeeTooLow(max_required))
+}
+
+/// The input dbcs will be spent on the network, and the resulting
+/// dbcs (and change dbc if any) are returned.
+/// This will pay transfer fees if not in data-network.
+#[allow(clippy::result_large_err)]
+fn reissue(
+    // client: &Client,
+    reissue_inputs: ReissueInputs,
+    // reason: DbcReason,
+) -> Result<ReissueOutputs> {
+    let ReissueInputs {
+        input_dbcs,
+        outputs,
+        change: (change, change_to),
+        // #[cfg(not(feature = "data-network"))]
+        // fees_paid,
+        // #[cfg(not(feature = "data-network"))]
+        // all_fee_cipher_params,
+    } = reissue_inputs;
+
+    let mut inputs = vec![];
+    for (dbc, derived_key) in input_dbcs {
+        let revealed_amount = match dbc.revealed_amount(&derived_key) {
+            Ok(amount) => amount,
+            Err(err) => {
+                warn!("Ignoring dbc, as it didn't have the correct derived key: {err}");
+                continue;
+            }
+        };
+        let input = InputHistory {
+            input: RevealedInput::new(derived_key, revealed_amount),
+            input_src_tx: dbc.src_tx,
+        };
+        inputs.push(input);
+    }
+
+    let mut tx_builder = TransactionBuilder::default()
+        .add_inputs(inputs)
+        .add_outputs(outputs);
+
+    let mut rng = rng::thread_rng();
+
+    let dbc_id_src = change_to.random_dbc_id_src(&mut rng);
+    if change.as_nano() > 0 {
+        tx_builder = tx_builder.add_output(change, dbc_id_src);
+    }
+
+    // let inputs_spent_proofs: BTreeSet<SpentProof> = input_dbcs
+    //     .iter()
+    //     .flat_map(|dbc| dbc.inputs_spent_proofs.clone())
+    //     .collect();
+    // let inputs_spent_transactions: BTreeSet<DbcTransaction> = input_dbcs
+    //     .iter()
+    //     .flat_map(|dbc| dbc.inputs_spent_transactions.clone())
+    //     .collect();
+
+    // Finalize the tx builder to get the dbc builder.
+    let dbc_builder = tx_builder
+        .build(Hash::default(), &mut rng)
+        .map_err(Error::DbcError)?;
+
+    // // Get fee outputs to generate the fee ciphers.
+    // #[cfg(not(feature = "data-network"))]
+    // let outputs = dbc_builder
+    //     .revealed_outputs
+    //     .iter()
+    //     .map(|output| (output.public_key, output.revealed_amount))
+    //     .collect();
+
+    let inputs = dbc_builder.signed_spends();
+    let spent_dbcs = inputs.iter().map(|spent| spent.dbc_id()).cloned().collect();
+
+    // // Spend all the input DBCs, collecting the spent proof shares for each of them
+    // for (public_key, tx) in inputs {
+    //     // // Generate the fee ciphers.
+    //     // #[cfg(not(feature = "data-network"))]
+    //     // let input_fee_ciphers = {
+    //     //     let fee_cipher_params = all_fee_cipher_params
+    //     //         .get(&public_key)
+    //     //         .ok_or(Error::DbcReissueError("Missing fee!".to_string()))?;
+    //     //     fee_ciphers(&outputs, fee_cipher_params)?
+    //     // };
+
+    //     let tx_hash = Hash::from(tx.hash());
+    //     // TODO: spend DBCs concurrently spawning tasks
+    //     let mut attempts = 0;
+    //     loop {
+    //         attempts += 1;
+    //         client
+    //             .spend_dbc(
+    //                 public_key,
+    //                 tx.clone(),
+    //                 reason,
+    //                 inputs_spent_proofs.clone(),
+    //                 inputs_spent_transactions.clone(),
+    //                 #[cfg(not(feature = "data-network"))]
+    //                 input_fee_ciphers.clone(),
+    //             )
+    //             .await?;
+
+    //         let signed_spend = client.get_signed_spend(public_key).await?;
+    //     }
+    // }
+
+    // Perform verifications of input TX and spentproofs,
+    // as well as building the output DBCs.
+    let mut output_dbcs = dbc_builder.build().map_err(Error::DbcError)?;
+
+    let mut change_dbc = None;
+    output_dbcs.retain(|(dbc, _)| {
+        if dbc.public_address() == &change_to && change.as_nano() > 0 {
+            change_dbc = Some(dbc.clone());
+            false
+        } else {
+            true
+        }
+    });
+
+    Ok(ReissueOutputs {
+        outputs: output_dbcs,
+        change: change_dbc,
+        spent_dbcs,
+        // #[cfg(not(feature = "data-network"))]
+        // fees_paid,
+    })
+}
+
+///
+#[allow(clippy::result_large_err)]
+pub(crate) fn select_inputs(
+    inputs: Vec<(Dbc, DerivedKey)>,
+    outputs: Vec<(Token, DbcIdSource)>,
+    change_to: PublicAddress,
+) -> Result<ReissueInputs> {
+    // We'll combine one or more input DBCs and reissue:
+    // - one output DBC per recipient,
+    // - and a single DBC for the change - if any - which will be returned from this function.
+    let mut input_dbcs = Vec::new();
+    let mut total_input_amount = Token::zero();
+    let total_output_amount = outputs
+        .iter()
+        .fold(Some(Token::zero()), |total, (amount, _)| {
+            total.and_then(|t| t.checked_add(*amount))
+        })
+        .ok_or_else(|| {
+            Error::DbcReissueError(
+                "Overflow occurred while summing the output amounts for the output DBCs."
+                    .to_string(),
+            )
+        })?;
+
+    let mut change_amount = total_output_amount;
+    // let mut rng = rng::thread_rng();
+    // #[cfg(not(feature = "data-network"))]
+    // let mut all_fee_cipher_params = BTreeMap::new();
+    // #[cfg(not(feature = "data-network"))]
+    // let mut fees_paid = Token::zero();
+
+    for (dbc, derived_key) in inputs {
+        // let revealed_amount = match dbc.revealed_amount(derived_key).map_err(Error::DbcError) {
+        //     Ok(revealed) => revealed,
+        //     Err(error) => {
+        //         error!(
+        //             "Could not get the amount from dbc {:?}, wrong derived key used! {error}",
+        //             dbc.id(),
+        //         );
+        //         continue;
+        //     }
+        // };
+
+        let input_key = dbc.id();
+
+        #[cfg(not(feature = "data-network"))]
+        {
+            // // ------------ fee part start ----------------
+            // #[cfg(not(feature = "data-network"))]
+            // let fee_per_input = {
+            //     // Each section will have elder_count() instances to pay individually (for now, later they will be more).
+            //     let elder_fees = match client.get_section_fees(input_key, priority).await {
+            //         Ok(fees) => fees,
+            //         Err(error) => {
+            //             error!("Could not get fees for input dbc: {input_key:?}: {error}");
+            //             continue;
+            //         }
+            //     };
+            //     let num_responses = elder_fees.len();
+            //     let required_responses = supermajority(elder_count());
+            //     if required_responses > num_responses {
+            //         warn!("Not enough elders contacted for the section to spend the input. Got: {num_responses}, needed: {required_responses}");
+            //         continue;
+            //     }
+
+            //     // Fees that were not encrypted to us.
+            //     let mut invalid_fees = BTreeSet::new();
+            //     // As the Elders encrypt the amount to our public key, we need to decrypt it.
+            //     let mut decrypted_elder_fees = vec![];
+
+            //     for (elder, fee) in elder_fees {
+            //         match fee.content.decrypt_amount(&revealed_bearer.secret_key) {
+            //             Ok(amount) => decrypted_elder_fees.push(((elder, fee), amount)),
+            //             Err(error) => {
+            //                 error!("Decrypting the fee content from {elder} failed! {error}");
+            //                 let _ = invalid_fees.insert(fee.content.elder_reward_key);
+            //             }
+            //         }
+            //     }
+
+            //     let max_invalid_fees = elder_count() - required_responses;
+            //     if invalid_fees.len() > max_invalid_fees {
+            //         let valid_responses = num_responses - invalid_fees.len();
+            //         warn!("Not enough valid fees received from the section to spend the input. Found: {valid_responses}, needed: {required_responses}", );
+            //         continue;
+            //     }
+
+            //     // Total fee paid to all recipients in the section for this input.
+            //     let fee_per_input = decrypted_elder_fees
+            //         .iter()
+            //         .fold(Some(Token::zero()), |total, (_, fee)| {
+            //             total.and_then(|t| t.checked_add(*fee))
+            //         })
+            //         .ok_or_else(|| Error::DbcReissueError(
+            //             "Overflow occurred while summing the individual Elder's fees in order to calculate the total amount for the output DBCs."
+            //                 .to_string(),
+            //         ))?;
+
+            //     let mut fee_cipher_params = BTreeMap::new();
+
+            //     // Add elders to outputs and generate their fee ciphers.
+            //     decrypted_elder_fees
+            //         .iter()
+            //         .for_each(|((elder, required_fee), fee)| {
+            //             let owner = Owner::from(required_fee.content.elder_reward_key);
+            //             let owner_once = OwnerOnce::from_owner_base(owner, &mut rng);
+            //             outputs.push((*fee, owner_once.clone()));
+
+            //             let _ =
+            //                 fee_cipher_params.insert(elder.name(), (required_fee.clone(), owner_once));
+            //         });
+
+            //     let _ = all_fee_cipher_params.insert(input_key, fee_cipher_params);
+
+            //     fees_paid = fees_paid.checked_add(fee_per_input).ok_or_else(|| {
+            //         Error::DbcReissueError(
+            //             "Overflow occurred while summing all the input fees.".to_string(),
+            //         )
+            //     })?;
+
+            //     fee_per_input
+            // };
+            // // ---------------- fee part end ----------------
+        }
+
+        let dbc_balance = match dbc.revealed_amount(&derived_key) {
+            Ok(revealed_amount) => Token::from_nano(revealed_amount.value()),
+            Err(err) => {
+                warn!("Ignoring input Dbc (id: {input_key:?}) due to not having correct derived key: {err:?}");
+                continue;
+            }
+        };
+
+        // Add this Dbc as input to be spent.
+        input_dbcs.push((dbc, derived_key));
+
+        // Input amount increases with the amount of the dbc.
+        total_input_amount = total_input_amount.checked_add(dbc_balance)
+            .ok_or_else(|| {
+                Error::DbcReissueError(
+                    "Overflow occurred while increasing total input amount while trying to cover the output DBCs."
+                    .to_string(),
+            )
+            })?;
+
+        #[cfg(not(feature = "data-network"))]
+        {
+            // // Output amount now increases a bit, as we have to cover the fee as well..
+            // total_output_amount = total_output_amount.checked_add(fee_per_input)
+            // .ok_or_else(|| {
+            //     Error::DbcReissueError(
+            //     "Overflow occurred while adding mint fee in order to calculate the total amount for the output DBCs."
+            //         .to_string(),
+            // )
+            // })?;
+            // // ..and so does `change_amount` (that we subtract from to know if we've covered `total_output_amount`).
+            // change_amount = change_amount.checked_add(fee_per_input)
+            // .ok_or_else(|| {
+            //     Error::DbcReissueError(
+            //     "Overflow occurred while adding mint fee in order to calculate the total amount for the output DBCs."
+            //         .to_string(),
+            // )
+            // })?;
+        }
+
+        // If we've already combined input DBCs for the total output amount, then stop.
+        match change_amount.checked_sub(dbc_balance) {
+            Some(pending_output) => {
+                change_amount = pending_output;
+                if change_amount.as_nano() == 0 {
+                    break;
+                }
+            }
+            None => {
+                change_amount = Token::from_nano(dbc_balance.as_nano() - change_amount.as_nano());
+                break;
+            }
+        }
+    }
+
+    // If not enough spendable was found, this check will return an error.
+    verify_amounts(total_input_amount, total_output_amount)?;
+
+    Ok(ReissueInputs {
+        input_dbcs,
+        outputs,
+        change: (change_amount, change_to),
+        // #[cfg(not(feature = "data-network"))]
+        // fees_paid,
+        // #[cfg(not(feature = "data-network"))]
+        // all_fee_cipher_params,
+    })
+}
+
+// Make sure total input amount gathered with input DBCs are enough for the output amount
+#[allow(clippy::result_large_err)]
+fn verify_amounts(total_input_amount: Token, total_output_amount: Token) -> Result<()> {
+    if total_output_amount > total_input_amount {
+        return Err(Error::NotEnoughBalance(total_input_amount.to_string()));
+    }
+    Ok(())
+}
+
+// type ReissueCiphers = BTreeMap<PublicKey, BTreeMap<XorName, (RequiredFee, OwnerOnce)>>;
+
+///
+#[derive(Debug)]
+pub struct ReissueInputs {
+    /// The dbcs to spend, as to send tokens.
+    pub input_dbcs: Vec<(Dbc, DerivedKey)>,
+    /// The dbcs that will be created, holding the tokens to send.
+    pub outputs: Vec<(Token, DbcIdSource)>,
+    /// Any surplus amount after spending the necessary input dbcs.
+    pub change: (Token, PublicAddress),
+    // /// Total fees to pay for spending the inputs.
+    // #[cfg(not(feature = "data-network"))]
+    // pub fees_paid: Token,
+    // /// This is the set of input dbc keys, each having a set of
+    // /// Elder names and their respective fee ciphers.
+    // /// Sent together with spends, so that Elders can verify their fee payments.
+    // #[cfg(not(feature = "data-network"))]
+    // pub all_fee_cipher_params: ReissueCiphers,
+}
+
+/// The results of reissuing dbcs.
+#[derive(Debug)]
+pub struct ReissueOutputs {
+    /// The dbcs holding the tokens that were sent.
+    pub outputs: Vec<(Dbc, RevealedAmount)>,
+    /// The dbc holding surplus amount after spending the necessary input dbcs.
+    pub change: Option<Dbc>,
+    /// The dbcs we spent when reissuing.
+    pub spent_dbcs: BTreeSet<DbcId>,
+    // /// Total fees to paid for this tx.
+    // #[cfg(not(feature = "data-network"))]
+    // pub fees_paid: Token,
 }

--- a/safenode/src/protocol/types/dbc_genesis.rs
+++ b/safenode/src/protocol/types/dbc_genesis.rs
@@ -7,11 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use sn_dbc::{
-    rng, Dbc, DbcId, DbcIdSource, DbcTransaction, DerivedKey, Error as DbcError, Hash,
-    InputHistory, MainKey, PublicAddress, RevealedAmount, RevealedInput, Token, TransactionBuilder,
+    rng, Dbc, DbcTransaction, Error as DbcError, Hash, InputHistory, MainKey, RevealedAmount,
+    RevealedInput, Token, TransactionBuilder,
 };
 
-use std::{collections::BTreeSet, fmt::Debug, result};
+use std::fmt::Debug;
 use thiserror::Error;
 
 /// Amount of tokens to be owned by the Genesis DBC.
@@ -21,7 +21,7 @@ use thiserror::Error;
 pub const GENESIS_DBC_AMOUNT: u64 = u32::MAX as u64 * u64::pow(10, 9);
 
 /// A specialised `Result` type for types crate.
-pub type GenesisResult<T> = result::Result<T, GenesisError>;
+pub type GenesisResult<T> = Result<T, GenesisError>;
 
 /// Main error type for the crate.
 #[derive(Error, Debug, Clone)]
@@ -89,224 +89,4 @@ pub fn create_genesis_dbc(genesis_main_key: &MainKey) -> GenesisResult<Dbc> {
     })?;
 
     Ok(genesis_dbc)
-}
-
-pub(super) type Result<T> = std::result::Result<T, Error>;
-
-/// Error type returned by the API
-#[derive(Debug, Error)]
-#[allow(clippy::large_enum_variant)]
-#[non_exhaustive]
-pub enum Error {
-    /// Not enough balance to perform a transaction
-    #[error("Not enough balance: {0}")]
-    NotEnoughBalance(String),
-    /// Not enough was paid in fees for the Elders to process the spend.
-    #[error("Too low amount for the transfer. Highest required fee: {0:?}.")]
-    FeeTooLow(Token),
-    /// DbcError
-    #[error("DbcError: {0}")]
-    DbcError(#[from] DbcError),
-    /// DbcReissueError
-    #[error("DbcReissueError: {0}")]
-    DbcReissueError(String),
-    /// Verification of DBC validly signed by a known section failed
-    #[error("DBC validity verification failed: {0}")]
-    DbcVerificationFailed(String),
-}
-
-/// Send the tokens to the specified destination keys, using the provided dbcs.
-/// The new dbcs that are created, one per specified destination, will have the
-/// unique id which is the public key of the `OwnerOnce` instances provided.
-///
-/// Transfer fees will be paid if not in data-network.
-/// The input dbcs will be spent on the network, and the resulting
-/// dbcs (and change dbc if any) are returned.
-/// NB: We are skipping the DbcReason arg for now. It can be added later.
-#[allow(clippy::result_large_err)]
-pub fn send_tokens(
-    dbcs: Vec<(Dbc, DerivedKey)>,
-    recipients: Vec<(Token, DbcIdSource)>,
-    change_to: PublicAddress,
-) -> Result<ReissueOutputs> {
-    // We need to select the necessary number of dbcs from those that we were passed.
-    // This will also account for any fees.
-    let reissue_inputs = select_inputs(dbcs, recipients, change_to)?;
-    reissue(reissue_inputs)
-}
-
-/// The input dbcs will be spent on the network, and the resulting
-/// dbcs (and change dbc if any) are returned.
-/// This will pay transfer fees if not in data-network.
-#[allow(clippy::result_large_err)]
-fn reissue(
-    // client: &Client,
-    reissue_inputs: ReissueInputs,
-    // reason: DbcReason,
-) -> Result<ReissueOutputs> {
-    let ReissueInputs {
-        input_dbcs,
-        outputs,
-        change: (change, change_to),
-    } = reissue_inputs;
-
-    let mut inputs = vec![];
-    for (dbc, derived_key) in input_dbcs {
-        let revealed_amount = match dbc.revealed_amount(&derived_key) {
-            Ok(amount) => amount,
-            Err(err) => {
-                warn!("Ignoring dbc, as it didn't have the correct derived key: {err}");
-                continue;
-            }
-        };
-        let input = InputHistory {
-            input: RevealedInput::new(derived_key, revealed_amount),
-            input_src_tx: dbc.src_tx,
-        };
-        inputs.push(input);
-    }
-
-    let mut tx_builder = TransactionBuilder::default()
-        .add_inputs(inputs)
-        .add_outputs(outputs);
-
-    let mut rng = rng::thread_rng();
-
-    let dbc_id_src = change_to.random_dbc_id_src(&mut rng);
-    if change.as_nano() > 0 {
-        tx_builder = tx_builder.add_output(change, dbc_id_src);
-    }
-
-    // Finalize the tx builder to get the dbc builder.
-    let dbc_builder = tx_builder
-        .build(Hash::default(), &mut rng)
-        .map_err(Error::DbcError)?;
-
-    let inputs = dbc_builder.signed_spends();
-    let spent_dbcs = inputs.iter().map(|spent| spent.dbc_id()).cloned().collect();
-
-    // Perform verifications of input TX and spentproofs,
-    // as well as building the output DBCs.
-    let mut output_dbcs = dbc_builder.build().map_err(Error::DbcError)?;
-
-    let mut change_dbc = None;
-    output_dbcs.retain(|(dbc, _)| {
-        if dbc.public_address() == &change_to && change.as_nano() > 0 {
-            change_dbc = Some(dbc.clone());
-            false
-        } else {
-            true
-        }
-    });
-
-    Ok(ReissueOutputs {
-        outputs: output_dbcs,
-        change: change_dbc,
-        spent_dbcs,
-    })
-}
-
-///
-#[allow(clippy::result_large_err)]
-pub(crate) fn select_inputs(
-    inputs: Vec<(Dbc, DerivedKey)>,
-    outputs: Vec<(Token, DbcIdSource)>,
-    change_to: PublicAddress,
-) -> Result<ReissueInputs> {
-    // We'll combine one or more input DBCs and reissue:
-    // - one output DBC per recipient,
-    // - and a single DBC for the change - if any - which will be returned from this function.
-    let mut input_dbcs = Vec::new();
-    let mut total_input_amount = Token::zero();
-    let total_output_amount = outputs
-        .iter()
-        .fold(Some(Token::zero()), |total, (amount, _)| {
-            total.and_then(|t| t.checked_add(*amount))
-        })
-        .ok_or_else(|| {
-            Error::DbcReissueError(
-                "Overflow occurred while summing the output amounts for the output DBCs."
-                    .to_string(),
-            )
-        })?;
-
-    let mut change_amount = total_output_amount;
-
-    for (dbc, derived_key) in inputs {
-        let input_key = dbc.id();
-
-        let dbc_balance = match dbc.revealed_amount(&derived_key) {
-            Ok(revealed_amount) => Token::from_nano(revealed_amount.value()),
-            Err(err) => {
-                warn!("Ignoring input Dbc (id: {input_key:?}) due to not having correct derived key: {err:?}");
-                continue;
-            }
-        };
-
-        // Add this Dbc as input to be spent.
-        input_dbcs.push((dbc, derived_key));
-
-        // Input amount increases with the amount of the dbc.
-        total_input_amount = total_input_amount.checked_add(dbc_balance)
-            .ok_or_else(|| {
-                Error::DbcReissueError(
-                    "Overflow occurred while increasing total input amount while trying to cover the output DBCs."
-                    .to_string(),
-            )
-            })?;
-
-        // If we've already combined input DBCs for the total output amount, then stop.
-        match change_amount.checked_sub(dbc_balance) {
-            Some(pending_output) => {
-                change_amount = pending_output;
-                if change_amount.as_nano() == 0 {
-                    break;
-                }
-            }
-            None => {
-                change_amount = Token::from_nano(dbc_balance.as_nano() - change_amount.as_nano());
-                break;
-            }
-        }
-    }
-
-    // If not enough spendable was found, this check will return an error.
-    verify_amounts(total_input_amount, total_output_amount)?;
-
-    Ok(ReissueInputs {
-        input_dbcs,
-        outputs,
-        change: (change_amount, change_to),
-    })
-}
-
-// Make sure total input amount gathered with input DBCs are enough for the output amount
-#[allow(clippy::result_large_err)]
-fn verify_amounts(total_input_amount: Token, total_output_amount: Token) -> Result<()> {
-    if total_output_amount > total_input_amount {
-        return Err(Error::NotEnoughBalance(total_input_amount.to_string()));
-    }
-    Ok(())
-}
-
-///
-#[derive(Debug)]
-pub struct ReissueInputs {
-    /// The dbcs to spend, as to send tokens.
-    pub input_dbcs: Vec<(Dbc, DerivedKey)>,
-    /// The dbcs that will be created, holding the tokens to send.
-    pub outputs: Vec<(Token, DbcIdSource)>,
-    /// Any surplus amount after spending the necessary input dbcs.
-    pub change: (Token, PublicAddress),
-}
-
-/// The results of reissuing dbcs.
-#[derive(Debug)]
-pub struct ReissueOutputs {
-    /// The dbcs holding the tokens that were sent.
-    pub outputs: Vec<(Dbc, RevealedAmount)>,
-    /// The dbc holding surplus amount after spending the necessary input dbcs.
-    pub change: Option<Dbc>,
-    /// The dbcs we spent when reissuing.
-    pub spent_dbcs: BTreeSet<DbcId>,
 }

--- a/safenode/src/protocol/types/mod.rs
+++ b/safenode/src/protocol/types/mod.rs
@@ -18,5 +18,7 @@ pub mod dbc_genesis;
 pub mod error;
 /// Register type.
 pub mod register;
+/// Token transfers.
+pub mod transfers;
 /// A wallet for network tokens.
 pub mod wallet;

--- a/safenode/src/protocol/types/transfers/error.rs
+++ b/safenode/src/protocol/types/transfers/error.rs
@@ -1,0 +1,35 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use sn_dbc::{Error as DbcError, Token};
+
+use thiserror::Error;
+
+pub(crate) type Result<T> = std::result::Result<T, Error>;
+
+/// Error type returned by the API
+#[derive(Debug, Error)]
+#[allow(clippy::large_enum_variant)]
+#[non_exhaustive]
+pub enum Error {
+    /// Not enough balance to perform a transaction
+    #[error("Not enough balance: {0}")]
+    NotEnoughBalance(String),
+    /// Not enough was paid in fees for the Elders to process the spend.
+    #[error("Too low amount for the transfer. Highest required fee: {0:?}.")]
+    FeeTooLow(Token),
+    /// DbcError
+    #[error("DbcError: {0}")]
+    Dbcs(#[from] DbcError),
+    /// DbcReissueFailed
+    #[error("DbcReissueFailed: {0}")]
+    DbcReissueFailed(String),
+    /// Verification of DBC validly signed by a known section failed
+    #[error("DBC validity verification failed: {0}")]
+    DbcVerificationFailed(String),
+}

--- a/safenode/src/protocol/types/transfers/mod.rs
+++ b/safenode/src/protocol/types/transfers/mod.rs
@@ -1,0 +1,215 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+mod error;
+
+use error::{Error, Result};
+
+use sn_dbc::{
+    rng, Dbc, DbcId, DbcIdSource, DerivedKey, Hash, InputHistory, PublicAddress, RevealedAmount,
+    RevealedInput, Token, TransactionBuilder,
+};
+
+use std::{collections::BTreeSet, fmt::Debug};
+
+/// The input details to a transfer of tokens.
+#[derive(Debug)]
+pub struct Inputs {
+    /// The dbcs to spend, as to transfer their tokens.
+    pub input_dbcs: Vec<(Dbc, DerivedKey)>,
+    /// The dbcs that will be created, holding the transferred tokens.
+    pub outputs: Vec<(Token, DbcIdSource)>,
+    /// Any surplus amount after spending the necessary input dbcs.
+    pub change: (Token, PublicAddress),
+}
+
+/// The token transfer results.
+#[derive(Debug)]
+pub struct Outputs {
+    /// The dbcs holding the tokens that were transferred.
+    pub outputs: Vec<(Dbc, RevealedAmount)>,
+    /// The ids of the dbcs we spent in this transfer.
+    pub spent_dbcs: BTreeSet<DbcId>,
+    /// The dbc holding surplus amount after spending the necessary input dbcs.
+    pub change: Option<Dbc>,
+}
+
+/// A function for creating an offline transfer of tokens.
+/// This is done by creating new dbcs to the recipients (and a change dbc if any)
+/// by selecting from the available input dbcs, and creating the necessary
+/// spends to do so.
+///
+/// Those signed spends are found in each new dbc, and must be uploaded to the network
+/// for the transactions to take effect.
+/// The peers will validate each signed spend they receive, before accepting it.
+/// Once enough peers have accepted all the spends of the transaction, and serve
+/// them upon request, the transaction will be completed.
+///
+/// (Disabled for now: Transfer fees will be added if not in data-network.)
+/// (Disabled for now: DbcReason, can be added later.)
+#[allow(clippy::result_large_err)]
+pub fn create_transfer(
+    dbcs: Vec<(Dbc, DerivedKey)>,
+    recipients: Vec<(Token, DbcIdSource)>,
+    change_to: PublicAddress,
+) -> Result<Outputs> {
+    // We need to select the necessary number of dbcs from those that we were passed.
+    // This will also account for any fees.
+    let send_inputs = select_inputs(dbcs, recipients, change_to)?;
+    transfer(send_inputs)
+}
+
+/// The tokens of the input dbcs will be transfered to the
+/// new dbcs (and a change dbc if any), which are returned from this function.
+/// This does not register the transaction in the network.
+/// To do that, the `signed_spends` of each new dbc, has to be uploaded
+/// to the network. When those same signed spends can be retrieved from
+/// enough peers in the network, the transaction will be completed.
+#[allow(clippy::result_large_err)]
+fn transfer(send_inputs: Inputs) -> Result<Outputs> {
+    let Inputs {
+        input_dbcs,
+        outputs,
+        change: (change, change_to),
+    } = send_inputs;
+
+    let mut inputs = vec![];
+    for (dbc, derived_key) in input_dbcs {
+        let revealed_amount = match dbc.revealed_amount(&derived_key) {
+            Ok(amount) => amount,
+            Err(err) => {
+                warn!("Ignoring dbc, as it didn't have the correct derived key: {err}");
+                continue;
+            }
+        };
+        let input = InputHistory {
+            input: RevealedInput::new(derived_key, revealed_amount),
+            input_src_tx: dbc.src_tx,
+        };
+        inputs.push(input);
+    }
+
+    let mut tx_builder = TransactionBuilder::default()
+        .add_inputs(inputs)
+        .add_outputs(outputs);
+
+    let mut rng = rng::thread_rng();
+
+    let dbc_id_src = change_to.random_dbc_id_src(&mut rng);
+    if change.as_nano() > 0 {
+        tx_builder = tx_builder.add_output(change, dbc_id_src);
+    }
+
+    // Finalize the tx builder to get the dbc builder.
+    let dbc_builder = tx_builder
+        .build(Hash::default(), &mut rng)
+        .map_err(Error::Dbcs)?;
+
+    let signed_spends = dbc_builder.signed_spends();
+    let spent_dbcs = signed_spends.iter().map(|spent| *spent.dbc_id()).collect();
+
+    // Perform verifications of input TX and spentproofs,
+    // as well as building the output DBCs.
+    let mut output_dbcs = dbc_builder.build().map_err(Error::Dbcs)?;
+
+    let mut change_dbc = None;
+    output_dbcs.retain(|(dbc, _)| {
+        if dbc.public_address() == &change_to && change.as_nano() > 0 {
+            change_dbc = Some(dbc.clone());
+            false
+        } else {
+            true
+        }
+    });
+
+    Ok(Outputs {
+        outputs: output_dbcs,
+        change: change_dbc,
+        spent_dbcs,
+    })
+}
+
+///
+#[allow(clippy::result_large_err)]
+pub(crate) fn select_inputs(
+    inputs: Vec<(Dbc, DerivedKey)>,
+    outputs: Vec<(Token, DbcIdSource)>,
+    change_to: PublicAddress,
+) -> Result<Inputs> {
+    let mut input_dbcs = Vec::new();
+    let mut total_input_amount = Token::zero();
+    let total_output_amount = outputs
+        .iter()
+        .fold(Some(Token::zero()), |total, (amount, _)| {
+            total.and_then(|t| t.checked_add(*amount))
+        })
+        .ok_or_else(|| {
+            Error::DbcReissueFailed(
+                "Overflow occurred while summing the output amounts for the output DBCs."
+                    .to_string(),
+            )
+        })?;
+
+    let mut change_amount = total_output_amount;
+
+    for (dbc, derived_key) in inputs {
+        let input_key = dbc.id();
+
+        let dbc_balance = match dbc.revealed_amount(&derived_key) {
+            Ok(revealed_amount) => Token::from_nano(revealed_amount.value()),
+            Err(err) => {
+                warn!("Ignoring input Dbc (id: {input_key:?}) due to not having correct derived key: {err:?}");
+                continue;
+            }
+        };
+
+        // Add this Dbc as input to be spent.
+        input_dbcs.push((dbc, derived_key));
+
+        // Input amount increases with the amount of the dbc.
+        total_input_amount = total_input_amount.checked_add(dbc_balance)
+            .ok_or_else(|| {
+                Error::DbcReissueFailed(
+                    "Overflow occurred while increasing total input amount while trying to cover the output DBCs."
+                    .to_string(),
+            )
+            })?;
+
+        // If we've already combined input DBCs for the total output amount, then stop.
+        match change_amount.checked_sub(dbc_balance) {
+            Some(pending_output) => {
+                change_amount = pending_output;
+                if change_amount.as_nano() == 0 {
+                    break;
+                }
+            }
+            None => {
+                change_amount = Token::from_nano(dbc_balance.as_nano() - change_amount.as_nano());
+                break;
+            }
+        }
+    }
+
+    // If not enough spendable was found, this check will return an error.
+    verify_amounts(total_input_amount, total_output_amount)?;
+
+    Ok(Inputs {
+        input_dbcs,
+        outputs,
+        change: (change_amount, change_to),
+    })
+}
+
+// Make sure total input amount gathered with input DBCs are enough for the output amount
+#[allow(clippy::result_large_err)]
+fn verify_amounts(total_input_amount: Token, total_output_amount: Token) -> Result<()> {
+    if total_output_amount > total_input_amount {
+        return Err(Error::NotEnoughBalance(total_input_amount.to_string()));
+    }
+    Ok(())
+}

--- a/safenode/src/protocol/types/wallet/error.rs
+++ b/safenode/src/protocol/types/wallet/error.rs
@@ -6,17 +6,23 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-/// Address types
-pub mod address;
-/// Data/content Authority types.
-pub mod authority;
-/// Chunk type.
-pub mod chunk;
-/// Dbc genesis creation.
-pub mod dbc_genesis;
-/// Errors.
-pub mod error;
-/// Register type.
-pub mod register;
-/// A wallet for network tokens.
-pub mod wallet;
+use thiserror::Error;
+
+/// Specialisation of `std::Result`.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Payment errors.
+#[derive(Debug, Error)]
+pub enum Error {
+    ///
+    #[error("Current balance: {balance}. Attempted spend: {attempted_spend}")]
+    NotEnoughBalance {
+        ///
+        balance: sn_dbc::Token,
+        ///
+        attempted_spend: sn_dbc::Token,
+    },
+    ///
+    #[error("Failed to send tokens due to {0}")]
+    CouldNotSendTokens(String),
+}

--- a/safenode/src/protocol/types/wallet/local_store.rs
+++ b/safenode/src/protocol/types/wallet/local_store.rs
@@ -1,0 +1,383 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::Result;
+
+use async_trait::async_trait;
+use std::collections::{BTreeMap, BTreeSet};
+
+// use crate::dbcs::DbcReason as Reason; // Later also use Reason in send api.
+use sn_dbc::{Dbc, DbcId, DbcIdSource, MainKey, PublicAddress, Token};
+
+///
+#[async_trait]
+pub trait SendWallet<C: SendClient> {
+    ///
+    fn new(key: MainKey, client: C) -> Self;
+    // fn load_from(path: &Path) -> Self;
+    ///
+    fn address(&self) -> PublicAddress;
+    ///
+    fn balance(&self) -> Token;
+    /// Used to generate a new dbc id for receiving tokens.
+    fn new_dbc_address(&self) -> DbcIdSource;
+    /// Will only deposit those that are actually accessible by this wallet.
+    fn deposit(&mut self, dbcs: Vec<Dbc>);
+    ///
+    async fn send(&mut self, to: Vec<(Token, PublicAddress)>) -> Result<Vec<NewDbc>>;
+}
+
+///
+pub trait DepositWallet {
+    ///
+    fn new(key: MainKey) -> Self;
+    // fn load_from(path: &Path) -> Self;
+    ///
+    fn address(&self) -> PublicAddress;
+    ///
+    fn balance(&self) -> Token;
+    /// Used to generate a new dbc id for receiving tokens.
+    fn new_dbc_address(&self) -> DbcIdSource;
+    /// Will only deposit those that are actually accessible by this wallet.
+    fn deposit(&mut self, dbcs: Vec<Dbc>);
+}
+
+///
+pub struct LocalSendWallet<C: SendClient> {
+    client: C,
+    wallet: LocalDepositWallet,
+}
+
+///
+pub struct LocalDepositWallet {
+    /// The secret key with which we can access
+    /// all the tokens in the available_dbcs.
+    key: MainKey,
+    /// The current balance of the wallet.
+    balance: Token,
+    /// These are dbcs we've owned, that have been
+    /// spent when sending tokens to other addresses.
+    spent_dbcs: BTreeMap<DbcId, Dbc>,
+    /// These are the dbcs we own that are not yet spent.
+    available_dbcs: BTreeMap<DbcId, Dbc>,
+    /// These are the dbcs we've created by
+    /// sending tokens to other addresses.
+    output_history: Vec<NewDbc>,
+    // local_store: std::path::PathBuf,
+}
+
+impl DepositWallet for LocalDepositWallet {
+    fn new(key: MainKey) -> Self {
+        Self {
+            key,
+            balance: Token::zero(),
+            spent_dbcs: BTreeMap::new(),
+            available_dbcs: BTreeMap::new(),
+            output_history: vec![],
+        }
+    }
+
+    // /// Loads a serialized wallet from a path.
+    // fn load_from(path: &Path) -> Self {
+    //     Self {
+    //     }
+    // }
+
+    fn address(&self) -> PublicAddress {
+        self.key.public_address()
+    }
+
+    fn balance(&self) -> Token {
+        self.balance
+    }
+
+    fn new_dbc_address(&self) -> DbcIdSource {
+        self.key.random_dbc_id_src(&mut rand::thread_rng())
+    }
+
+    fn deposit(&mut self, dbcs: Vec<Dbc>) {
+        if dbcs.is_empty() {
+            return;
+        }
+
+        let mut new_dbcs = dbcs
+            .into_iter()
+            .filter_map(|dbc| {
+                let id = dbc.id();
+                (!self.spent_dbcs.contains_key(&id)).then_some((id, dbc))
+            })
+            .filter_map(|(id, dbc)| {
+                dbc.as_revealed_input(&self.key)
+                    .is_ok()
+                    .then_some((id, dbc))
+            })
+            .collect();
+
+        self.available_dbcs.append(&mut new_dbcs);
+
+        let new_balance = self
+            .available_dbcs
+            .iter()
+            .flat_map(|(_, dbc)| dbc.as_revealed_input(&self.key))
+            .fold(0, |total, amount| total + amount.revealed_amount().value());
+
+        self.balance = Token::from_nano(new_balance);
+    }
+}
+
+#[async_trait]
+impl<C: SendClient + Send + Sync + Clone> SendWallet<C> for LocalSendWallet<C> {
+    fn new(key: MainKey, client: C) -> Self {
+        Self {
+            client,
+            wallet: LocalDepositWallet::new(key),
+        }
+    }
+
+    fn address(&self) -> PublicAddress {
+        self.wallet.address()
+    }
+
+    fn balance(&self) -> Token {
+        self.wallet.balance()
+    }
+
+    fn new_dbc_address(&self) -> DbcIdSource {
+        self.wallet.new_dbc_address()
+    }
+
+    fn deposit(&mut self, dbcs: Vec<Dbc>) {
+        self.wallet.deposit(dbcs)
+    }
+
+    async fn send(&mut self, to: Vec<(Token, PublicAddress)>) -> Result<Vec<NewDbc>> {
+        // do not make a pointless send to ourselves
+        let to: Vec<_> = to
+            .into_iter()
+            .filter_map(|(amount, key)| (key != self.address()).then_some((amount, key)))
+            .collect();
+        if to.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let available_dbcs = self.wallet.available_dbcs.values().cloned().collect();
+
+        let client = self.client.clone();
+        let SpendInfo {
+            change,
+            spent_dbcs,
+            mut new_dbcs,
+        } = client.send(available_dbcs, to).await?; // this should return Result and which dbcs that were spent
+
+        let mut spent_dbcs = spent_dbcs
+            .into_iter()
+            .filter_map(|id| self.wallet.available_dbcs.remove(&id).map(|dbc| (id, dbc)))
+            .collect();
+
+        self.deposit(change.into_iter().collect());
+        self.wallet.spent_dbcs.append(&mut spent_dbcs);
+        self.wallet.output_history.append(&mut new_dbcs);
+
+        Ok(new_dbcs)
+    }
+}
+
+///
+#[async_trait]
+pub trait SendClient {
+    ///
+    async fn send(&self, dbcs: Vec<Dbc>, to: Vec<(Token, PublicAddress)>) -> Result<SpendInfo>;
+}
+
+///
+pub struct NewDbc {
+    ///
+    pub dbc: Dbc,
+    ///
+    pub recipient: PublicAddress,
+    ///
+    pub amount: sn_dbc::RevealedAmount,
+}
+
+///
+pub struct SpendInfo {
+    /// Any surplus tokens from the last spent dbc.
+    pub change: Option<Dbc>,
+    /// The dbcs that were spent when sending
+    /// the tokens.
+    pub spent_dbcs: BTreeSet<DbcId>,
+    /// The dbcs that were created containing
+    /// the tokens sent to respective recipient.
+    pub new_dbcs: Vec<NewDbc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DepositWallet, LocalDepositWallet, Result, SendClient, SpendInfo};
+
+    use crate::protocol::types::{dbc_genesis::{
+        create_genesis_dbc, Result as GenesisResult, GENESIS_DBC_AMOUNT,
+    }, wallet::{LocalSendWallet, SendWallet}};
+
+    use sn_dbc::{Dbc, MainKey, PublicAddress, Token};
+
+    use bls::SecretKey;
+    use std::collections::BTreeSet;
+
+    /// -----------------------------------
+    /// <-------> DepositWallet <--------->
+    /// -----------------------------------
+
+    #[test]
+    fn deposit_wallet_basics() -> Result<()> {
+        let main_key = MainKey::new(SecretKey::random());
+        let public_address = main_key.public_address();
+        let local_wallet: LocalDepositWallet = DepositWallet::new(main_key);
+
+        assert_eq!(public_address, local_wallet.address());
+        assert_eq!(
+            public_address,
+            local_wallet.new_dbc_address().public_address
+        );
+        assert_eq!(Token::zero(), local_wallet.balance());
+
+        assert!(local_wallet.available_dbcs.is_empty());
+        assert!(local_wallet.output_history.is_empty());
+        assert!(local_wallet.spent_dbcs.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn deposit_empty_list_does_nothing() -> Result<()> {
+        let mut local_wallet: LocalDepositWallet =
+            DepositWallet::new(MainKey::new(SecretKey::random()));
+
+        local_wallet.deposit(vec![]);
+
+        assert_eq!(Token::zero(), local_wallet.balance());
+
+        assert!(local_wallet.available_dbcs.is_empty());
+        assert!(local_wallet.output_history.is_empty());
+        assert!(local_wallet.spent_dbcs.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn deposit_adds_dbcs_that_belongs_to_the_wallet() -> GenesisResult<()> {
+        let genesis_key = MainKey::new(SecretKey::random());
+        let genesis = create_genesis_dbc(&genesis_key)?;
+
+        let mut local_wallet: LocalDepositWallet = DepositWallet::new(genesis_key);
+
+        local_wallet.deposit(vec![genesis]);
+
+        assert_eq!(GENESIS_DBC_AMOUNT, local_wallet.balance().as_nano());
+
+        Ok(())
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn deposit_does_not_add_dbcs_not_belonging_to_the_wallet() -> GenesisResult<()> {
+        let genesis_key = MainKey::new(SecretKey::random());
+        let genesis = create_genesis_dbc(&genesis_key)?;
+
+        let wallet_key = MainKey::new(SecretKey::random());
+        let mut local_wallet: LocalDepositWallet = DepositWallet::new(wallet_key);
+
+        local_wallet.deposit(vec![genesis]);
+
+        assert_eq!(Token::zero(), local_wallet.balance());
+
+        Ok(())
+    }
+
+    /// --------------------------------
+    /// <-------> SendWallet <--------->
+    /// --------------------------------
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn send_wallet_basics() -> GenesisResult<()> {
+        let main_key = MainKey::new(SecretKey::random());
+        let public_address = main_key.public_address();
+        let client = MockSendClient::new();
+        let send_wallet: LocalSendWallet::<MockSendClient> = SendWallet::<MockSendClient>::new(main_key, client);
+
+        assert_eq!(public_address, send_wallet.address());
+        assert_eq!(
+            public_address,
+            send_wallet.new_dbc_address().public_address
+        );
+        assert_eq!(Token::zero(), send_wallet.balance());
+
+        assert!(send_wallet.wallet.available_dbcs.is_empty());
+        assert!(send_wallet.wallet.output_history.is_empty());
+        assert!(send_wallet.wallet.spent_dbcs.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[allow(clippy::result_large_err)]
+    async fn sending_decreases_balance() -> Result<()> {
+        let genesis_key = MainKey::new(SecretKey::random());
+        let genesis = create_genesis_dbc(&genesis_key).unwrap();
+
+        let client = MockSendClient::new();
+        let mut send_wallet: LocalSendWallet::<MockSendClient> = SendWallet::<MockSendClient>::new(genesis_key, client);
+
+        send_wallet.deposit(vec![genesis]);
+
+        assert_eq!(GENESIS_DBC_AMOUNT, send_wallet.balance().as_nano());
+
+        // We send to ourselves.
+        let to = vec![(Token::from_nano(100), genesis_key.public_address())];
+        let new_dbcs = send_wallet.send(to).await?;
+
+        assert_eq!(GENESIS_DBC_AMOUNT - 100, send_wallet.balance().as_nano());
+        assert_eq!(1, new_dbcs.len());
+        for n in new_dbcs {
+            assert_eq!(100, n.amount.value());
+            assert_eq!(genesis_key.public_address(), n.recipient);
+        }
+
+        send_wallet.deposit(new_dbcs.iter().map(|n| n.dbc.clone()).collect());
+
+        assert_eq!(GENESIS_DBC_AMOUNT, send_wallet.balance().as_nano());
+
+        Ok(())
+    }
+
+    #[derive(Clone)]
+    struct MockSendClient {}
+
+    impl MockSendClient {
+        fn new() -> Self {
+            Self {}
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SendClient for MockSendClient {
+        async fn send(
+            &self,
+            _dbcs: Vec<Dbc>,
+            _to: Vec<(Token, PublicAddress)>,
+        ) -> Result<SpendInfo> {
+            Ok(SpendInfo {
+                change: None,
+                spent_dbcs: BTreeSet::new(),
+                new_dbcs: vec![],
+            })
+        }
+    }
+}

--- a/safenode/src/protocol/types/wallet/mod.rs
+++ b/safenode/src/protocol/types/wallet/mod.rs
@@ -1,0 +1,45 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! An implementation of a local Wallet used by clients and nodes (the latter use them for their rewards).
+//! There is one which is deposit only, and one which can also send tokens.
+//!
+//! Later, a network Wallet store can be implemented thusly:
+//! 1. Chunk each Dbc.
+//! 2. For a semi-public Wallet:
+//!     a. Store a register with address of your `PublicAddress`.
+//!    Then push these ops:
+//!     b. self.address.encrypt(Deposit(ChunkAddress))
+//!     c. self.address.encrypt(Spend(ChunkAddress))
+//!    And when the register has used 1023 entries:
+//!     d. self.address.encrypt(Extend(RegisterAddress))
+//!     ... which would occupy the last entry, and thus link to a new register.
+//! 3. For a private Wallet:
+//!     a. Store a register with address of self.address.encrypt(self.address).
+//!     ... then follow from b. in 2.
+//! 4. Then, when a wallet is to be loaded from the network:
+//!     a. Get the `PublicAddress` from your secret.
+//!     b. Fetch the register with address of either the plaintext of or the encrypted `PublicAddress`.
+//!     c. Decrypt all entries and apply the ops to your Wallet, to get the current state of it.
+//!     d. If there is another register linked at the end of this one, follow that link and repeat steps b., c. and d.
+//!
+//! We will already now pave for that, by mimicing that flow for the local storage of a Wallet.
+//! First though, a simpler local storage will be used. But after that a local register store can be implemented.
+
+mod error;
+mod local_store;
+mod network_store;
+
+pub use self::{
+    error::{Error, Result},
+    local_store::{
+        DepositWallet, LocalDepositWallet, LocalSendWallet, NewDbc, SendClient, SendWallet,
+        SpendInfo,
+    },
+    // network_store::NetworkWallet,
+};

--- a/safenode/src/protocol/types/wallet/mod.rs
+++ b/safenode/src/protocol/types/wallet/mod.rs
@@ -10,7 +10,7 @@
 //! There is one which is deposit only, and one which can also send tokens.
 //!
 //! Later, a network Wallet store can be implemented thusly:
-//! 1. Chunk each Dbc.
+//! 1. Chunk each Dbc, both spent and available.
 //! 2. For a semi-public Wallet:
 //!     a. Store a register with address of your `PublicAddress`.
 //!    Then push these ops:
@@ -37,9 +37,73 @@ mod network_store;
 
 pub use self::{
     error::{Error, Result},
-    local_store::{
-        DepositWallet, LocalDepositWallet, LocalSendWallet, NewDbc, SendClient, SendWallet,
-        SpendInfo,
-    },
+    local_store::{LocalDepositWallet, LocalSendWallet},
     // network_store::NetworkWallet,
 };
+
+use super::transfers::{CreatedDbc, Outputs as TransferDetails};
+
+use sn_dbc::{Dbc, DbcIdSource, DerivedKey, MainKey, PublicAddress, Token};
+
+use async_trait::async_trait;
+
+/// A SendClient is used to transfer tokens to other addresses.
+///
+/// It does so by creating a transfer and returning that to the caller.
+/// It is expected that the implementation of this trait is a network client,
+/// that will also upload the transfer to the network before returning it.
+/// The network will validate the transfer upon receiving it. Once enough peers have accepted it,
+/// the transfer is completed.
+///  
+/// For tests the implementation can be a local client with no network connection,
+/// that will just return the transfer to the caller.
+#[async_trait]
+pub trait SendClient {
+    ///
+    async fn send(
+        &self,
+        dbcs: Vec<(Dbc, DerivedKey)>,
+        to: Vec<(Token, DbcIdSource)>,
+        change_to: PublicAddress,
+    ) -> Result<TransferDetails>;
+}
+
+/// A send wallet is a wallet that can send tokens to other addresses.
+/// It is also a deposit wallet, so it can receive tokens from other wallets.
+#[async_trait]
+pub trait SendWallet<C: SendClient> {
+    // /// Loads a wallet from the given path.
+    // fn load_from(path: &Path) -> Self;
+    /// Creates a new wallet with the given key.
+    fn new(key: MainKey, client: C) -> Self;
+    /// The address of the wallet, to which others send tokens.
+    fn address(&self) -> PublicAddress;
+    /// The current balance of the wallet.
+    fn balance(&self) -> Token;
+    /// Used to generate a new dbc id for receiving tokens.
+    fn new_dbc_address(&self) -> DbcIdSource;
+    /// Will only deposit those that are actually accessible by this wallet.
+    fn deposit(&mut self, dbcs: Vec<Dbc>);
+    /// Sends the given tokens to the given addresses.
+    /// Returns the new dbcs that were created.
+    /// Depending on the implementation of the send client, this may
+    /// also register the transaction with the network.
+    async fn send(&mut self, to: Vec<(Token, PublicAddress)>) -> Result<Vec<CreatedDbc>>;
+}
+
+/// A deposit wallet is a wallet that can receive tokens from other wallets.
+/// It can however not send tokens to other addresses.
+pub trait DepositWallet {
+    // /// Loads a wallet from the given path.
+    // fn load_from(path: &Path) -> Self;
+    /// Creates a new wallet with the given key.
+    fn new(key: MainKey) -> Self;
+    /// The address of the wallet, to which others send tokens.
+    fn address(&self) -> PublicAddress;
+    /// The current balance of the wallet.
+    fn balance(&self) -> Token;
+    /// Used to generate a new dbc id for receiving tokens.
+    fn new_dbc_address(&self) -> DbcIdSource;
+    /// Will only deposit those that are actually accessible by this wallet.
+    fn deposit(&mut self, dbcs: Vec<Dbc>);
+}

--- a/safenode/src/protocol/types/wallet/network_store.rs
+++ b/safenode/src/protocol/types/wallet/network_store.rs
@@ -5,18 +5,3 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
-
-/// Address types
-pub mod address;
-/// Data/content Authority types.
-pub mod authority;
-/// Chunk type.
-pub mod chunk;
-/// Dbc genesis creation.
-pub mod dbc_genesis;
-/// Errors.
-pub mod error;
-/// Register type.
-pub mod register;
-/// A wallet for network tokens.
-pub mod wallet;


### PR DESCRIPTION
An implementation of a local `Wallet` used by clients and nodes (the latter use them for their rewards).
There is one which is deposit only, and one which can also send tokens.

Later, a network `Wallet` store can be implemented thusly:
1. Chunk each `Dbc`, both spent and available.
2. For a semi-public `Wallet`:
     a. Store a register with address of your `PublicAddress`.
    Then push these ops:
     b. `self.address.encrypt(Deposit(ChunkAddress))`
     c. `self.address.encrypt(Spend(ChunkAddress))`
    And when the register has used `1023` entries:
     d. `self.address.encrypt(Extend(RegisterAddress))`
     ... which would occupy the last entry, and thus link to a new register.
 3. For a private `Wallet`:
     a. Store a register with address of `self.address.encrypt(self.address)`.
     ... then follow from b. in 2.
 4. Then, when a `Wallet` is to be loaded from the network:
     a. Get the `PublicAddress` from your secret.
     b. Fetch the register with address of either the plaintext of or the encrypted `PublicAddress`.
     c. Decrypt all entries and apply the ops to your `Wallet`, to get the current state of it.
     d. If there is another register linked at the end of this one, follow that link and repeat steps b., c. and d.

 We will already now pave for that, by mimicing that flow for the local storage of a `Wallet`.
 First though, a simpler local storage will be used. But after that a local register store can be implemented.