### PR TITLE
feat(api): Register client API

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -168,7 +168,7 @@ jobs:
         timeout-minutes: 2
 
       - name: Start a client to carry out register actions
-        run: cargo run --release --bin safe -- --create-register --query-register confirm_created
+        run: cargo run --release --bin safe -- --create-register myregister --query-register myregister
         id: client-register-actions
         env:
           RUST_LOG: "safenode,safe=trace"

--- a/README.md
+++ b/README.md
@@ -8,17 +8,33 @@ This is an experimental branch for layering safe network data structures atop li
 
 ## Actions undertaken by a client accessing the network
 
-- Create Register
-`cargo run --release --bin safe -- --create-register`
+- Create Register with nickname 'myregister'
+`cargo run --release --bin safe -- --create-register myregister`
 
-- Get Register; copy the `XorName` of the register from the previous command
-`cargo run --release --bin safe -- --query-register xor_name`
+- Get Register using its nickname from the previous command
+`cargo run --release --bin safe -- --query-register myregister`
 
 - Put files
 `cargo run --release --bin safe -- --upload-chunks ~/dir/with/files`
 
 - Get files; copy the `XorName` of the file from the previous command
 `cargo run --release --bin safe -- --get-chunk xor_name`
+
+## Using example app which exercises the Register APIs
+
+You can run the `registers` example client app from multiple consoles simultaneously,
+to write to the same Register on the network, identified by its nickname and
+using different user names from each instance launched, e.g.:
+
+From first console:
+```
+cargo run --release --example registers -- --user alice --reg-nickname myregister
+```
+
+From a second console:
+```
+cargo run --release --example registers -- --user bob --reg-nickname myregister
+```
 
 ### Notes
 

--- a/safenode/examples/registers.rs
+++ b/safenode/examples/registers.rs
@@ -1,0 +1,120 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use safenode::client::{Client, ClientEvent, Error};
+
+use bls::SecretKey;
+use clap::Parser;
+use eyre::Result;
+use std::{io, time::Duration};
+use tokio::time::sleep;
+use xor_name::XorName;
+
+#[derive(Parser, Debug)]
+#[clap(name = "registers cli")]
+struct Opt {
+    #[clap(long)]
+    user: String,
+
+    #[clap(long)]
+    reg_nickname: String,
+
+    #[clap(long, default_value_t = 2000)]
+    delay_millis: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let opt = Opt::parse();
+    let user = opt.user;
+    let reg_nickname = opt.reg_nickname;
+    let delay = Duration::from_millis(opt.delay_millis);
+
+    // let's build a random secret key to sign our Register ops
+    let signer = SecretKey::random();
+
+    println!("Starting SAFE client...");
+    let client = Client::new(signer)?;
+
+    // Let's wait till we are connected to the network before proceeding further
+    let mut client_events_rx = client.events_channel();
+    loop {
+        if let Ok(ClientEvent::ConnectedToNetwork) = client_events_rx.recv().await {
+            println!("Connected to the Network!");
+            break;
+        }
+    }
+
+    // we'll retrieve (or create if not found) a Register, and write on it
+    // in offline mode, syncing with the network periodically.
+    let tag = 5000;
+    let xorname = XorName::from_content(reg_nickname.as_bytes());
+    println!("Retrieving Register '{reg_nickname}' from SAFE, as user '{user}'");
+    let mut reg_replica = match client.get_register(xorname, tag).await {
+        Ok(register) => {
+            println!(
+                "Register '{reg_nickname}' found at {}, {}!",
+                register.name(),
+                register.tag(),
+            );
+            register.offline()
+        }
+        Err(_) => {
+            println!("Register '{reg_nickname}' not found, creating it at {xorname}, {tag}",);
+            client.create_register(xorname, tag).await?.offline()
+        }
+    };
+
+    // We'll loop asking for new msg to write onto the Register offline,
+    // then we'll be syncing the offline Register with the network, i.e.
+    // both pushing and ulling all changes made to it by us and other clients/users.
+    // If we detect branches when trying to write, after we synced with remote
+    // replicas of the Register, we'll merge them all back into a single value.
+    loop {
+        println!();
+        println!("Latest value (more than one if concurrent writes were made):");
+        println!("--------------");
+        for (_, entry) in reg_replica.read().into_iter() {
+            println!("{}", String::from_utf8(entry)?);
+        }
+        println!("--------------");
+
+        let input_text = prompt_user();
+        println!("Writing msg (offline) to Register: '{input_text}'");
+        let msg = format!("[{user}]: {input_text}");
+        match reg_replica.write(msg.as_bytes()) {
+            Ok(()) => {}
+            Err(Error::ContentBranchDetected(branches)) => {
+                println!(
+                    "Branches ({}) detected in Register, let's merge them all...",
+                    branches.len()
+                );
+                reg_replica.write_merging_branches(msg.as_bytes())?;
+            }
+            Err(err) => return Err(err.into()),
+        }
+
+        // Sync with network after a delay
+        println!("Syncing with SAFE in {delay:?}...");
+        sleep(delay).await;
+        println!("synced!");
+
+        reg_replica.sync().await?;
+    }
+}
+
+fn prompt_user() -> String {
+    let mut input_text = String::new();
+    println!();
+    println!("Enter new text to write onto the Register:");
+    io::stdin()
+        .read_line(&mut input_text)
+        .expect("Failed to read text from stdin");
+
+    input_text.trim().to_string()
+}

--- a/safenode/src/bin/kadclient.rs
+++ b/safenode/src/bin/kadclient.rs
@@ -6,28 +6,42 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use bincode::serialize;
+use safenode::{
+    client::{Client, ClientEvent, Error as ClientError},
+    log::init_node_logging,
+    protocol::types::{address::ChunkAddress, chunk::Chunk},
+};
+
 use bls::SecretKey;
 use bytes::Bytes;
 use clap::Parser;
 use eyre::Result;
-use safenode::{
-    client::{Client, ClientEvent},
-    log::init_node_logging,
-    protocol::{
-        messages::{CreateRegister, EditRegister, SignedRegisterCreate, SignedRegisterEdit},
-        types::{
-            address::{ChunkAddress, RegisterAddress},
-            authority::DataAuthority,
-            chunk::Chunk,
-            register::{Policy, Register, User},
-        },
-    },
-};
-use std::{collections::BTreeSet, fs, path::PathBuf};
-use tracing::{info, warn};
+use std::{fs, path::PathBuf};
+use tracing::info;
 use walkdir::WalkDir;
 use xor_name::XorName;
+
+#[derive(Parser, Debug)]
+#[clap(name = "safeclient cli")]
+struct Opt {
+    #[clap(long)]
+    log_dir: Option<PathBuf>,
+
+    #[clap(long)]
+    upload_chunks: Option<PathBuf>,
+
+    #[clap(long)]
+    get_chunk: Option<String>,
+
+    #[clap(long)]
+    create_register: Option<String>,
+
+    #[clap(long)]
+    entry: Option<String>,
+
+    #[clap(long)]
+    query_register: Vec<String>,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -35,7 +49,9 @@ async fn main() -> Result<()> {
     let _log_appender_guard = init_node_logging(&opt.log_dir)?;
 
     info!("Instantiating a SAFE client...");
-    let client = Client::new()?;
+    // let's build a random secret key to sign our Register ops
+    let signer = SecretKey::random();
+    let client = Client::new(signer)?;
 
     let mut client_events_rx = client.events_channel();
     if let Ok(event) = client_events_rx.recv().await {
@@ -53,22 +69,22 @@ async fn main() -> Result<()> {
             if entry.file_type().is_file() {
                 let file = fs::read(entry.path())?;
                 let chunk = Chunk::new(Bytes::from(file));
-                let xor_name = *chunk.name();
+                let xorname = *chunk.name();
                 info!(
-                    "Storing chunk {:?} with xorname: {xor_name:x}",
+                    "Storing chunk {:?} with xorname: {xorname:x}",
                     entry.file_name()
                 );
                 println!(
-                    "Storing chunk {:?} with xorname: {xor_name:x}",
+                    "Storing chunk {:?} with xorname: {xorname:x}",
                     entry.file_name()
                 );
                 match client.store_chunk(chunk).await {
                     Ok(()) => {
-                        info!("Successfully stored chunk {xor_name:?}");
-                        chunks_to_fetch.push(xor_name);
+                        info!("Successfully stored chunk {xorname:?}");
+                        chunks_to_fetch.push(xorname);
                     }
                     Err(error) => {
-                        panic!("Did not store chunk {xor_name:?} to all nodes in the close group! {error}")
+                        panic!("Did not store chunk {xorname:?} to all nodes in the close group! {error}")
                     }
                 };
             }
@@ -79,129 +95,73 @@ async fn main() -> Result<()> {
         println!("String passed in via get_chunk is {input_str}...");
         if input_str.len() == 64 {
             let vec = hex::decode(input_str).expect("Failed to decode xorname!");
-            let mut xor_name = XorName::default();
-            xor_name.0.copy_from_slice(vec.as_slice());
-            chunks_to_fetch.push(xor_name);
+            let mut xorname = XorName::default();
+            xorname.0.copy_from_slice(vec.as_slice());
+            chunks_to_fetch.push(xorname);
         }
 
-        for xor_name in chunks_to_fetch.iter() {
-            println!("Fetching chunk {xor_name:?}");
-            match client.get_chunk(ChunkAddress::new(*xor_name)).await {
+        for xorname in chunks_to_fetch.iter() {
+            println!("Fetching chunk {xorname:?}");
+            match client.get_chunk(ChunkAddress::new(*xorname)).await {
                 Ok(chunk) => info!("Successfully got chunk {}!", chunk.name()),
                 Err(error) => {
-                    panic!("Did not get chunk {xor_name:?} from the close group! {error}")
+                    panic!("Did not get chunk {xorname:?} from the close group! {error}")
                 }
             };
         }
     }
 
-    let mut register_to_query = Vec::new();
-
-    if opt.create_register {
-        let mut rng = rand::thread_rng();
-        let xor_name = XorName::random(&mut rng);
-        info!("Creating Register with xorname: {xor_name:x}");
-
-        let sk = SecretKey::random();
-        let owner = User::Key(sk.public_key());
-        let policy = Policy {
-            owner,
-            permissions: Default::default(),
-        };
+    if let Some(reg_nickname) = opt.create_register {
+        let xorname = XorName::from_content(reg_nickname.as_bytes());
         let tag = 3006;
-        let op = CreateRegister {
-            name: xor_name,
-            tag,
-            policy: policy.clone(),
-        };
-        let auth = DataAuthority {
-            public_key: sk.public_key(),
-            signature: sk.sign(serialize(&op)?),
-        };
+        println!("Creating Register with '{reg_nickname}' at xorname: {xorname:x} and tag {tag}");
 
-        let cmd = SignedRegisterCreate { op, auth };
-
-        match client.create_register(cmd).await {
-            Ok(()) => {
-                register_to_query.push(xor_name);
-                info!("Successfully created register {xor_name:?}, {tag}!");
+        let mut reg_replica = match client.create_register(xorname, tag).await {
+            Ok(replica) => {
+                info!("Successfully created register '{reg_nickname}' at {xorname:?}, {tag}!");
+                replica
             }
             Err(error) => panic!(
-                "Did not create register {xor_name:?} on all nodes in the close group! {error}"
+                "Did not create register '{reg_nickname}' on all nodes in the close group! {error}"
             ),
         };
 
         if let Some(entry) = opt.entry {
-            let mut register = Register::new(owner, xor_name, tag, policy);
-            let (_, edit) = register.write(entry.into(), BTreeSet::default())?;
-            let op = EditRegister {
-                address: *register.address(),
-                edit,
-            };
-            let auth = DataAuthority {
-                public_key: sk.public_key(),
-                signature: sk.sign(serialize(&op)?),
-            };
-
-            let cmd = SignedRegisterEdit { op, auth };
-
-            match client.edit_register(cmd).await {
-                Ok(()) => info!("Successfully edited register {xor_name}, {tag}!"),
-                Err(error) => {
-                    warn!("Did not edit register on all nodes in the close group! {error}")
+            println!("Editing Register '{reg_nickname}' with: {entry}");
+            match reg_replica.write(entry.as_bytes()).await {
+                Ok(()) => {}
+                Err(ref err @ ClientError::ContentBranchDetected(ref branches)) => {
+                    println!(
+                        "We need to merge {} branches in Register entries: {err}",
+                        branches.len()
+                    );
+                    reg_replica.write_merging_branches(entry.as_bytes()).await?;
                 }
-            };
+                Err(err) => return Err(err.into()),
+            }
         }
     }
 
-    if let Some(input_str) = opt.query_register {
-        println!("String passed in via query_register is {input_str}...");
-        if input_str.len() == 64 {
-            let vec = hex::decode(input_str).expect("failed to decode xorname");
-            let mut xor_name = XorName::default();
-            xor_name.0.copy_from_slice(vec.as_slice());
-            register_to_query.push(xor_name);
-        }
-
+    if !opt.query_register.is_empty() {
         let tag = 3006;
-        for xor_name in register_to_query.iter() {
-            println!("Trying to retrieve Register {xor_name:?}");
-            let addr = RegisterAddress::new(*xor_name, tag);
+        for reg_nickname in opt.query_register.iter() {
+            println!("Register nickname passed in via --query-register is '{reg_nickname}'...");
+            let xorname = XorName::from_content(reg_nickname.as_bytes());
 
-            match client.get_register(addr).await {
-                Ok(register) => info!(
-                    "Successfully retrieved Register {}, {}!",
+            println!("Trying to retrieve Register from {xorname:?}, {tag}");
+
+            match client.get_register(xorname, tag).await {
+                Ok(register) => println!(
+                    "Successfully retrieved Register '{reg_nickname}' from {}, {}!",
                     register.name(),
                     register.tag()
                 ),
                 Err(error) => {
-                    panic!("Did not retrieve Register {xor_name:?} from all nodes in the close group! {error}")
+                    panic!("Did not retrieve Register '{reg_nickname}' from all nodes in the close group! {error}")
                 }
-            };
+            }
         }
     }
 
     Ok(())
-}
-
-#[derive(Parser, Debug)]
-#[clap(name = "safeclient cli")]
-struct Opt {
-    #[clap(long)]
-    log_dir: Option<PathBuf>,
-
-    #[clap(long)]
-    upload_chunks: Option<PathBuf>,
-
-    #[clap(long)]
-    get_chunk: Option<String>,
-
-    #[clap(long)]
-    create_register: bool,
-
-    #[clap(long)]
-    entry: Option<String>,
-
-    #[clap(long)]
-    query_register: Option<String>,
 }

--- a/safenode/src/client/error.rs
+++ b/safenode/src/client/error.rs
@@ -6,9 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use thiserror::Error;
-
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
+
+use crate::protocol::types::register::{Entry, EntryHash};
+
+use std::collections::BTreeSet;
+use thiserror::Error;
 
 /// Internal error.
 #[derive(Debug, Error)]
@@ -28,4 +31,13 @@ pub enum Error {
 
     #[error("Chunks error {0}.")]
     Chunks(#[from] super::chunks::Error),
+
+    #[error("Serialisation error: {0}")]
+    BincodeError(#[from] bincode::Error),
+
+    #[error(
+        "Content branches detected in the Register which need to be merged/resolved by user. \
+        Entries hashes of branches are: {0:?}"
+    )]
+    ContentBranchDetected(BTreeSet<(EntryHash, Entry)>),
 }

--- a/safenode/src/client/mod.rs
+++ b/safenode/src/client/mod.rs
@@ -11,16 +11,24 @@ mod chunks;
 mod error;
 mod event;
 mod file_apis;
+mod register;
 
-pub use self::event::{ClientEvent, ClientEventsReceiver};
+pub use self::{
+    error::Error,
+    event::{ClientEvent, ClientEventsReceiver},
+    register::{Register, RegisterOffline},
+};
 
 use self::event::ClientEventsChannel;
 
 use crate::network::Network;
 
-/// Client API implementation store and get data.
+use bls::SecretKey;
+
+/// Client API implementation to store and get data.
 #[derive(Clone)]
 pub struct Client {
     network: Network,
     events_channel: ClientEventsChannel,
+    signer: SecretKey,
 }

--- a/safenode/src/client/register/mod.rs
+++ b/safenode/src/client/register/mod.rs
@@ -1,0 +1,97 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+mod offline_replica;
+
+pub use offline_replica::RegisterOffline;
+
+use super::{error::Result, Client};
+
+use crate::protocol::types::register::{Entry, EntryHash, Policy};
+
+use std::collections::BTreeSet;
+use xor_name::XorName;
+
+/// Operations made to a Register instance are applied not only locally,
+/// but also sent them to the replicas on the network. The user can
+/// switch offline-mode by invoking the `offline` API.
+pub struct Register {
+    pub(super) offline_reg: RegisterOffline,
+}
+
+impl Register {
+    /// Create a new Register.
+    pub async fn create(client: Client, name: XorName, tag: u64) -> Result<Self> {
+        let mut offline_reg = RegisterOffline::create(client, name, tag)?;
+        offline_reg.push().await?;
+        Ok(Self { offline_reg })
+    }
+
+    /// Retrieve a Register from the network.
+    pub async fn get(client: Client, name: XorName, tag: u64) -> Result<Self> {
+        let offline_reg = RegisterOffline::retrieve(client, name, tag).await?;
+        Ok(Self { offline_reg })
+    }
+
+    /// Switch to 'offline' mode where each op is made only locally.
+    pub fn offline(self) -> RegisterOffline {
+        RegisterOffline::from(self)
+    }
+
+    /// Return the Policy of the Register.
+    pub fn policy(&self) -> &Policy {
+        self.offline_reg.policy()
+    }
+
+    /// Return the XorName of the Register.
+    pub fn name(&self) -> &XorName {
+        self.offline_reg.name()
+    }
+
+    /// Return the tag value of the Register.
+    pub fn tag(&self) -> u64 {
+        self.offline_reg.tag()
+    }
+
+    /// Write a new value onto the Register atop latest value.
+    /// It returns an error if it finds branches in the content/entries; if it is
+    /// required to merge/resolve the branches, invoke the `write_merging_branches` API.
+    pub async fn write(&mut self, entry: &[u8]) -> Result<()> {
+        self.offline_reg.write(entry)?;
+        self.offline_reg.push().await
+    }
+
+    /// Write a new value onto the Register atop latest value.
+    /// If there are branches of content/entries, it automatically merges them
+    /// all leaving the new value as a single latest value of the Register.
+    /// Note you can use `write` API instead if you need to handle
+    /// content/entries branches in a diffeerent way.
+    pub async fn write_merging_branches(&mut self, entry: &[u8]) -> Result<()> {
+        self.offline_reg.write_merging_branches(entry)?;
+        self.offline_reg.push().await
+    }
+
+    /// Write a new value onto the Register atop the set of braches/entries
+    /// referenced by the provided list of their corresponding entry hash.
+    /// Note you can use `write_merging_branches` API instead if you
+    /// want to write atop all exiting branches/entries.
+    pub async fn write_atop(&mut self, entry: &[u8], children: BTreeSet<EntryHash>) -> Result<()> {
+        self.offline_reg.write_atop(entry, children)?;
+        self.offline_reg.push().await
+    }
+
+    /// Read the last entry, or entries when there are branches, if the register is not empty.
+    pub fn read(&self) -> BTreeSet<(EntryHash, Entry)> {
+        self.offline_reg.read()
+    }
+
+    /// Sync this Register with the replicas on the network.
+    pub async fn sync(&mut self) -> Result<()> {
+        self.offline_reg.sync().await
+    }
+}

--- a/safenode/src/client/register/offline_replica.rs
+++ b/safenode/src/client/register/offline_replica.rs
@@ -1,0 +1,310 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{
+    super::error::{Error, Result},
+    Client, Register,
+};
+
+use crate::protocol::{
+    messages::{
+        Cmd, CmdResponse, CreateRegister, EditRegister, Query, QueryResponse, RegisterCmd,
+        RegisterQuery, Request, Response, SignedRegisterCreate, SignedRegisterEdit,
+    },
+    types::{
+        address::RegisterAddress,
+        authority::DataAuthority,
+        error::Error as ProtocolError,
+        register::{
+            Action, Entry, EntryHash, Permissions, Policy, Register as RegisterReplica, User,
+        },
+    },
+};
+
+use bincode::serialize;
+use std::collections::{BTreeSet, LinkedList};
+use xor_name::XorName;
+
+/// Ops made to an offline Register instance are applied locally only,
+/// and accumulated till the user explicitly calls 'sync'. The user can
+/// switch back to sync with the network for every op by invoking `online` API.
+pub struct RegisterOffline {
+    client: Client,
+    register: RegisterReplica,
+    ops: LinkedList<RegisterCmd>, // Cached operations.
+}
+
+impl RegisterOffline {
+    /// Create a new Register offline.
+    pub fn create(client: Client, name: XorName, tag: u64) -> Result<Self> {
+        Self::new(client, name, tag)
+    }
+
+    /// Retrieve a Register from the network to work on it offline.
+    pub(super) async fn retrieve(client: Client, name: XorName, tag: u64) -> Result<Self> {
+        let register = Self::get_register(&client, name, tag).await?;
+
+        Ok(Self {
+            client,
+            register,
+            ops: LinkedList::new(),
+        })
+    }
+
+    /// Instantiate a ReplicaOffline from a given Register instance.
+    pub(super) fn from(replica: Register) -> Self {
+        Self {
+            client: replica.offline_reg.client,
+            register: replica.offline_reg.register,
+            ops: LinkedList::new(),
+        }
+    }
+
+    /// Return the Policy of the Register.
+    pub fn policy(&self) -> &Policy {
+        self.register.policy()
+    }
+
+    /// Return the XorName of the Register.
+    pub fn name(&self) -> &XorName {
+        self.register.name()
+    }
+
+    /// Return the tag value of the Register.
+    pub fn tag(&self) -> u64 {
+        self.register.tag()
+    }
+
+    /// Write a new value onto the Register atop latest value.
+    /// It returns an error if it finds branches in the content/entries; if it is
+    /// required to merge/resolve the branches, invoke the `write_merging_branches` API.
+    pub fn write(&mut self, entry: &[u8]) -> Result<()> {
+        let children = self.register.read();
+        if children.len() > 1 {
+            return Err(Error::ContentBranchDetected(children));
+        }
+
+        self.write_atop(entry, children.into_iter().map(|(hash, _)| hash).collect())
+    }
+
+    /// Write a new value onto the Register atop latest value.
+    /// If there are branches of content/entries, it automatically merges them
+    /// all leaving the new value as a single latest value of the Register.
+    /// Note you can use `write` API instead if you need to handle
+    /// content/entries branches in a diffeerent way.
+    pub fn write_merging_branches(&mut self, entry: &[u8]) -> Result<()> {
+        let children: BTreeSet<EntryHash> = self
+            .register
+            .read()
+            .into_iter()
+            .map(|(hash, _)| hash)
+            .collect();
+
+        self.write_atop(entry, children)
+    }
+
+    /// Write a new value onto the Register atop the set of braches/entries
+    /// referenced by the provided list of their corresponding entry hash.
+    /// Note you can use `write_merging_branches` API instead if you
+    /// want to write atop all exiting branches/entries.
+    pub fn write_atop(&mut self, entry: &[u8], children: BTreeSet<EntryHash>) -> Result<()> {
+        // we need to check permissions first
+        let public_key = self.client.signer_pk();
+        self.register
+            .check_permissions(Action::Write, Some(User::Key(public_key)))?;
+
+        let (_hash, edit) = self.register.write(entry.into(), children)?;
+        let op = EditRegister {
+            address: *self.register.address(),
+            edit,
+        };
+        let auth = DataAuthority {
+            public_key,
+            signature: self.client.sign(&serialize(&op)?),
+        };
+        let cmd = RegisterCmd::Edit(SignedRegisterEdit { op, auth });
+
+        self.ops.push_front(cmd);
+
+        Ok(())
+    }
+
+    /// Read the last entry, or entries when there are branches, if the register is not empty.
+    pub fn read(&self) -> BTreeSet<(EntryHash, Entry)> {
+        self.register.read()
+    }
+
+    /// Sync this Register with the replicas on the network.
+    pub async fn sync(&mut self) -> Result<()> {
+        debug!("Syncing Register at {}, {}!", self.name(), self.tag(),);
+        // FIXME: handle the scenario where the Register doesn't exist on the network yet
+        let remote_replica = Self::get_register(&self.client, *self.name(), self.tag()).await?;
+        self.register.merge(remote_replica);
+        self.push().await
+    }
+
+    /// Push all operations made locally to the replicas of this Register on the network.
+    pub async fn push(&mut self) -> Result<()> {
+        let ops_len = self.ops.len();
+        if ops_len > 0 {
+            let name = *self.name();
+            let tag = self.tag();
+            debug!("Pushing {ops_len} cached Register cmds at {name}, {tag}!",);
+
+            // TODO: send them all concurrently
+            while let Some(cmd) = self.ops.pop_back() {
+                let result = match cmd {
+                    RegisterCmd::Create { .. } => self.publish_register_create(cmd.clone()).await,
+                    RegisterCmd::Edit { .. } => self.publish_register_edit(cmd.clone()).await,
+                };
+
+                if let Err(err) = result {
+                    warn!("Did not push Register cmd on all nodes in the close group!: {err}");
+                    // We keep the cmd for next sync to retry
+                    self.ops.push_back(cmd);
+                    return Err(err);
+                }
+            }
+
+            debug!("Successfully pushed {ops_len} Register cmds at {name}, {tag}!",);
+        }
+
+        Ok(())
+    }
+
+    /// Switch to 'online' mode where each op made locally is immediatelly pushed to the network.
+    pub async fn online(mut self) -> Result<Register> {
+        self.push().await?;
+        Ok(Register { offline_reg: self })
+    }
+
+    // ********* Private helpers  *********
+
+    // Create a new RegisterOffline instance with the given name and tag.
+    fn new(client: Client, name: XorName, tag: u64) -> Result<Self> {
+        let public_key = client.signer_pk();
+        let owner = User::Key(public_key);
+        let policy = Policy {
+            owner,
+            permissions: [(User::Anyone, Permissions::new(true))]
+                .into_iter()
+                .collect(),
+        };
+
+        let op = CreateRegister {
+            name,
+            tag,
+            policy: policy.clone(),
+        };
+        let auth = DataAuthority {
+            public_key,
+            signature: client.sign(&serialize(&op)?),
+        };
+        let create_cmd = RegisterCmd::Create(SignedRegisterCreate { op, auth });
+
+        let register = RegisterReplica::new(owner, name, tag, policy);
+        let reg = Self {
+            client,
+            register,
+            ops: LinkedList::from([create_cmd]),
+        };
+
+        Ok(reg)
+    }
+
+    // Publish a `Register` creation command on the network.
+    async fn publish_register_create(&self, cmd: RegisterCmd) -> Result<()> {
+        debug!("Publishing Register create cmd: {:?}", cmd.dst());
+        let request = Request::Cmd(Cmd::Register(cmd));
+        let responses = self.client.send_to_closest(request).await?;
+
+        let all_ok = responses
+            .iter()
+            .all(|resp| matches!(resp, Ok(Response::Cmd(CmdResponse::CreateRegister(Ok(()))))));
+        if all_ok {
+            return Ok(());
+        }
+
+        // If not all were Ok, we will return the first error sent to us.
+        for resp in responses.iter().flatten() {
+            if let Response::Cmd(CmdResponse::CreateRegister(result)) = resp {
+                result.clone()?;
+            };
+        }
+
+        // If there were no success or fail to the expected query,
+        // we check if there were any send errors.
+        for resp in responses {
+            let _ = resp?;
+        }
+
+        // If there were no register errors, then we had unexpected responses.
+        Err(Error::Protocol(ProtocolError::UnexpectedResponses))
+    }
+
+    // Publish a `Register` edit command in the network.
+    async fn publish_register_edit(&self, cmd: RegisterCmd) -> Result<()> {
+        debug!("Publishing Register edit cmd: {:?}", cmd.dst());
+        let request = Request::Cmd(Cmd::Register(cmd));
+        let responses = self.client.send_to_closest(request).await?;
+
+        let all_ok = responses
+            .iter()
+            .all(|resp| matches!(resp, Ok(Response::Cmd(CmdResponse::EditRegister(Ok(()))))));
+        if all_ok {
+            return Ok(());
+        }
+
+        // If not all were Ok, we will return the first error sent to us.
+        for resp in responses.iter().flatten() {
+            if let Response::Cmd(CmdResponse::EditRegister(result)) = resp {
+                result.clone()?;
+            };
+        }
+
+        // If there were no success or fail to the expected query,
+        // we check if there were any send errors.
+        for resp in responses {
+            let _ = resp?;
+        }
+
+        // If there were no register errors, then we had unexpected responses.
+        Err(Error::Protocol(ProtocolError::UnexpectedResponses))
+    }
+
+    // Retrieve a `Register` from the closest peers.
+    async fn get_register(client: &Client, name: XorName, tag: u64) -> Result<RegisterReplica> {
+        let address = RegisterAddress { name, tag };
+        debug!("Retrieving Register from: {address:?}");
+        let request = Request::Query(Query::Register(RegisterQuery::Get(address)));
+        let responses = client.send_to_closest(request).await?;
+
+        // We will return the first register we get.
+        for resp in responses.iter().flatten() {
+            if let Response::Query(QueryResponse::GetRegister(Ok(register))) = resp {
+                return Ok(register.clone());
+            };
+        }
+
+        // If no register was gotten, we will return the first error sent to us.
+        for resp in responses.iter().flatten() {
+            if let Response::Query(QueryResponse::GetChunk(result)) = resp {
+                let _ = result.clone()?;
+            };
+        }
+
+        // If there were no success or fail to the expected query,
+        // we check if there were any send errors.
+        for resp in responses {
+            let _ = resp?;
+        }
+
+        // If there was none of the above, then we had unexpected responses.
+        Err(Error::Protocol(ProtocolError::UnexpectedResponses))
+    }
+}

--- a/safenode/src/protocol/types/register/mod.rs
+++ b/safenode/src/protocol/types/register/mod.rs
@@ -42,7 +42,7 @@ pub type RegisterOp<T> = CrdtOperation<T>;
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub struct Register {
     authority: User,
-    pub(super) crdt: RegisterCrdt, // Temporarily exposed to 'super' till spentbook fully implemented.
+    crdt: RegisterCrdt, // Temporarily exposed to 'super' till spentbook fully implemented.
     policy: Policy,
 }
 
@@ -136,6 +136,11 @@ impl Register {
     pub fn apply_op(&mut self, op: RegisterOp<Entry>) -> Result<()> {
         self.check_entry_and_reg_sizes(&op.crdt_op.value)?;
         self.crdt.apply_op(op)
+    }
+
+    /// Merge another Register into this one.
+    pub fn merge(&mut self, other: Self) {
+        self.crdt.merge(other.crdt);
     }
 
     // Private helper to check the given Entry's size is within define limit,

--- a/safenode/src/protocol/types/register/reg_crdt.rs
+++ b/safenode/src/protocol/types/register/reg_crdt.rs
@@ -17,7 +17,7 @@ use super::{
 
 use crdts::{
     merkle_reg::{MerkleReg, Node},
-    CmRDT,
+    CmRDT, CvRDT,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -93,6 +93,11 @@ impl RegisterCrdt {
     /// Returns the address.
     pub(crate) fn address(&self) -> &RegisterAddress {
         &self.address
+    }
+
+    /// Merge another register into this one.
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.data.merge(other.data);
     }
 
     /// Returns total number of items in the register.


### PR DESCRIPTION
- Supports offline-first type of operations for users to work on Registers offline and syncing local changes with remote replicas on the network when they decide to.
- Public APIs for Register in offline mode are all sync, whilst those that work 'online', i.e. syncing right after each operation is made, are all `async`.
- Allow users to resolve/merge branches of Registers entries if their use case requires a single branch of values as content.

Resolves #80