### PR TITLE
feat: extend kadclient to up-/download files

### DIFF
--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -115,7 +115,7 @@ impl Client {
     }
 
     /// Store `Chunk` to its close group.
-    pub async fn store_chunk(&self, chunk: Chunk) -> Result<()> {
+    pub(super) async fn store_chunk(&self, chunk: Chunk) -> Result<()> {
         info!("Store chunk: {:?}", chunk.address());
         let request = Request::Cmd(Cmd::StoreChunk(chunk));
         let responses = self.send_to_closest(request).await?;
@@ -145,7 +145,7 @@ impl Client {
     }
 
     /// Retrieve a `Chunk` from the closest peers.
-    pub async fn get_chunk(&self, address: ChunkAddress) -> Result<Chunk> {
+    pub(super) async fn get_chunk(&self, address: ChunkAddress) -> Result<Chunk> {
         info!("Get chunk: {address:?}");
         let request = Request::Query(Query::GetChunk(address));
         let responses = self.send_to_closest(request).await?;

--- a/safenode/src/client/mod.rs
+++ b/safenode/src/client/mod.rs
@@ -16,6 +16,7 @@ mod register;
 pub use self::{
     error::Error,
     event::{ClientEvent, ClientEventsReceiver},
+    file_apis::Files,
     register::{Register, RegisterOffline},
 };
 


### PR DESCRIPTION
Resolves #100.

It can now upload and download entire files, instead of small chunks.

Additionally, the files apis are encapsulated in their own struct, as
to not bloat the client api.