### PR TITLE
feat(client): integrate wallet

### DIFF
--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -47,5 +47,6 @@ walkdir = "2.3.1"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-proptest = { version = "1.0.0" }
 assert_matches = "1.5.0"
+proptest = { version = "1.0.0" }
+tempfile = "3.2.0"

--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.2.1", features = ["derive"]}
 clru = "~0.6.1"
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 custom_debug = "~0.5.0"
+dirs-next = "~2.0.0"
 eyre = "0.6.8"
 file-rotate = "0.7.3"
 futures = "~0.3.13"

--- a/safenode/src/client/mod.rs
+++ b/safenode/src/client/mod.rs
@@ -12,24 +12,24 @@ mod error;
 mod event;
 mod file_apis;
 mod register;
+mod wallet;
 
 pub use self::{
     error::Error,
     event::{ClientEvent, ClientEventsReceiver},
     file_apis::Files,
     register::{Register, RegisterOffline},
+    wallet::WalletClient,
 };
 
 use self::event::ClientEventsChannel;
 
 use crate::network::Network;
 
-use bls::SecretKey;
-
 /// Client API implementation to store and get data.
 #[derive(Clone)]
 pub struct Client {
     network: Network,
     events_channel: ClientEventsChannel,
-    signer: SecretKey,
+    signer: bls::SecretKey,
 }

--- a/safenode/src/client/wallet.rs
+++ b/safenode/src/client/wallet.rs
@@ -1,0 +1,50 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use sn_dbc::{Dbc, DbcIdSource, DerivedKey, PublicAddress, Token};
+
+use crate::protocol::{
+    offline_transfers::{create_transfer, Outputs as TransferDetails},
+    wallet::{Result, SendClient, SendWallet},
+};
+
+use super::Client;
+
+/// A wallet client can be used to send and
+/// receive tokens to/from other wallets.
+pub struct WalletClient<W: SendWallet> {
+    client: Client,
+    wallet: W,
+}
+
+impl<W: SendWallet> WalletClient<W> {
+    /// Create a new wallet client.
+    pub fn new(client: Client, wallet: W) -> Self {
+        Self { client, wallet }
+    }
+
+    /// Send tokens to another wallet.
+    pub async fn send(&mut self, amount: Token, to: PublicAddress) -> Result<()> {
+        let _dbcs = self.wallet.send(vec![(amount, to)], &self.client).await?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl SendClient for Client {
+    async fn send(
+        &self,
+        dbcs: Vec<(Dbc, DerivedKey)>,
+        to: Vec<(Token, DbcIdSource)>,
+        change_to: PublicAddress,
+    ) -> Result<TransferDetails> {
+        let transfer = create_transfer(dbcs, to, change_to)?;
+
+        Ok(transfer)
+    }
+}

--- a/safenode/src/protocol/offline_transfers/error.rs
+++ b/safenode/src/protocol/offline_transfers/error.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_dbc::{Error as DbcError, Token};
+use sn_dbc::Error as DbcError;
 
 use thiserror::Error;
 
@@ -20,16 +20,10 @@ pub enum Error {
     /// Not enough balance to perform a transaction
     #[error("Not enough balance: {0}")]
     NotEnoughBalance(String),
-    /// Not enough was paid in fees for the nodes to process the spend.
-    #[error("Too low amount for the transfer. Highest required fee: {0:?}.")]
-    FeeTooLow(Token),
     /// An error from the `sn_dbc` crate.
     #[error("Dbc error: {0}")]
     Dbcs(#[from] DbcError),
     /// DbcReissueFailed
     #[error("DbcReissueFailed: {0}")]
     DbcReissueFailed(String),
-    /// Verification of DBC validly signed by a known section failed
-    #[error("DBC validity verification failed: {0}")]
-    DbcVerificationFailed(String),
 }

--- a/safenode/src/protocol/offline_transfers/mod.rs
+++ b/safenode/src/protocol/offline_transfers/mod.rs
@@ -64,7 +64,7 @@ pub struct Outputs {
 }
 
 /// A resulting dbc from a token transfer.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CreatedDbc {
     /// The dbc that was created.
     pub dbc: Dbc,

--- a/safenode/src/protocol/offline_transfers/mod.rs
+++ b/safenode/src/protocol/offline_transfers/mod.rs
@@ -29,7 +29,7 @@
 
 mod error;
 
-use error::{Error, Result};
+pub(crate) use error::{Error, Result};
 
 use sn_dbc::{
     rng, Dbc, DbcIdSource, DerivedKey, Hash, InputHistory, PublicAddress, RevealedAmount,

--- a/safenode/src/protocol/wallet/error.rs
+++ b/safenode/src/protocol/wallet/error.rs
@@ -25,4 +25,22 @@ pub enum Error {
     /// A general error when a transfer fails.
     #[error("Failed to send tokens due to {0}")]
     CouldNotSendTokens(String),
+    /// Failed to parse bytes into a bls key.
+    #[error("Failed to parse bls key")]
+    FailedToParseBlsKey,
+    /// Failed to decode a hex string to a key.
+    #[error("Could not decode hex string to key.")]
+    FailedToDecodeHexToKey,
+    /// Failed to serialize a main key to hex.
+    #[error("Could not serialize main key to hex: {0}")]
+    FailedToHexEncodeKey(String),
+    /// Bls error.
+    #[error("Bls error: {0}")]
+    Bls(#[from] bls::error::Error),
+    /// Bincode error.
+    #[error("Bincode error:: {0}")]
+    Bincode(#[from] bincode::Error),
+    /// I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
 }

--- a/safenode/src/protocol/wallet/error.rs
+++ b/safenode/src/protocol/wallet/error.rs
@@ -14,14 +14,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Transfer errors.
 #[derive(Debug, Error)]
 pub enum Error {
-    /// When a transfer is attempted with a higher amount than what is available.
-    #[error("Current balance: {balance}. Attempted spend: {attempted_spend}")]
-    NotEnoughBalance {
-        /// The actual balance available.
-        balance: sn_dbc::Token,
-        /// The amount to spend that was attempted.
-        attempted_spend: sn_dbc::Token,
-    },
+    /// Failed to create transfer.
+    #[error("CreateTransfer error {0}")]
+    CreateTransfer(#[from] crate::protocol::offline_transfers::Error),
     /// A general error when a transfer fails.
     #[error("Failed to send tokens due to {0}")]
     CouldNotSendTokens(String),

--- a/safenode/src/protocol/wallet/keys.rs
+++ b/safenode/src/protocol/wallet/keys.rs
@@ -8,8 +8,9 @@
 
 use super::error::{Error, Result};
 
-use hex::{decode, encode};
 use sn_dbc::MainKey;
+
+use hex::{decode, encode};
 use std::path::Path;
 use tokio::fs;
 
@@ -46,6 +47,7 @@ pub(super) async fn get_main_key(root_dir: &Path) -> Result<Option<MainKey>> {
 }
 
 /// Construct a BLS secret key from a hex-encoded string.
+#[allow(clippy::result_large_err)]
 fn bls_secret_from_hex<T: AsRef<[u8]>>(hex: T) -> Result<bls::SecretKey> {
     let bytes = decode(hex).map_err(|_| Error::FailedToDecodeHexToKey)?;
     let bytes_fixed_len: [u8; bls::SK_SIZE] = bytes
@@ -67,9 +69,9 @@ mod test {
     async fn reward_key_to_and_from_file() -> Result<()> {
         let main_key = MainKey::random();
         let dir = create_temp_dir()?;
-        let dir_path = dir.path();
-        store_new_keypair(dir_path, &main_key).await?;
-        let secret_result = get_main_key(dir_path)
+        let root_dir = dir.path().to_path_buf();
+        store_new_keypair(&root_dir, &main_key).await?;
+        let secret_result = get_main_key(&root_dir)
             .await?
             .expect("There to be a key on disk.");
         assert_eq!(secret_result.public_address(), main_key.public_address());

--- a/safenode/src/protocol/wallet/keys.rs
+++ b/safenode/src/protocol/wallet/keys.rs
@@ -1,0 +1,82 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::error::{Error, Result};
+
+use hex::{decode, encode};
+use sn_dbc::MainKey;
+use std::path::Path;
+use tokio::fs;
+
+/// Filename for storing the node's reward (BLS hex-encoded) main key.
+const MAIN_KEY_FILENAME: &str = "main_key";
+/// Filename for storing the node's reward (BLS hex-encoded) public address.
+const PUBLIC_ADDRESS_FILENAME: &str = "public_address";
+
+/// Writes the public address and main key (hex-encoded) to different locations at disk.
+pub(super) async fn store_new_keypair(root_dir: &Path, main_key: &MainKey) -> Result<()> {
+    let secret_key_path = root_dir.join(MAIN_KEY_FILENAME);
+    let public_key_path = root_dir.join(PUBLIC_ADDRESS_FILENAME);
+    fs::write(secret_key_path, encode(main_key.to_bytes())).await?;
+    fs::write(
+        public_key_path,
+        encode(main_key.public_address().to_bytes()),
+    )
+    .await
+    .map_err(|e| Error::FailedToHexEncodeKey(e.to_string()))?;
+    Ok(())
+}
+
+/// Returns Some(sn_dbc::MainKey) or None if file doesn't exist. It assumes it's hex-encoded.
+pub(super) async fn get_main_key(root_dir: &Path) -> Result<Option<MainKey>> {
+    let path = root_dir.join(MAIN_KEY_FILENAME);
+    if !path.is_file() {
+        return Ok(None);
+    }
+
+    let secret_hex_bytes = fs::read(&path).await?;
+    let secret = bls_secret_from_hex(secret_hex_bytes)?;
+
+    Ok(Some(MainKey::new(secret)))
+}
+
+/// Construct a BLS secret key from a hex-encoded string.
+fn bls_secret_from_hex<T: AsRef<[u8]>>(hex: T) -> Result<bls::SecretKey> {
+    let bytes = decode(hex).map_err(|_| Error::FailedToDecodeHexToKey)?;
+    let bytes_fixed_len: [u8; bls::SK_SIZE] = bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| Error::FailedToParseBlsKey)?;
+    let sk = bls::SecretKey::from_bytes(bytes_fixed_len)?;
+    Ok(sk)
+}
+
+#[cfg(test)]
+mod test {
+    use super::{get_main_key, store_new_keypair, MainKey};
+
+    use eyre::{eyre, Result};
+    use tempfile::{tempdir, TempDir};
+
+    #[tokio::test]
+    async fn reward_key_to_and_from_file() -> Result<()> {
+        let main_key = MainKey::random();
+        let dir = create_temp_dir()?;
+        let dir_path = dir.path();
+        store_new_keypair(dir_path, &main_key).await?;
+        let secret_result = get_main_key(dir_path)
+            .await?
+            .expect("There to be a key on disk.");
+        assert_eq!(secret_result.public_address(), main_key.public_address());
+        Ok(())
+    }
+
+    fn create_temp_dir() -> Result<TempDir> {
+        tempdir().map_err(|e| eyre!("Failed to create temp dir: {}", e))
+    }
+}

--- a/safenode/src/protocol/wallet/local_store.rs
+++ b/safenode/src/protocol/wallet/local_store.rs
@@ -6,47 +6,109 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{CreatedDbc, DepositWallet, Result, SendClient, SendWallet};
+use super::{
+    keys::{get_main_key, store_new_keypair},
+    wallet_file::{get_wallet, store_wallet},
+    CreatedDbc, DepositWallet, KeyLessWallet, Result, SendClient, SendWallet,
+};
 
 use crate::protocol::offline_transfers::Outputs as TransferDetails;
 
-use sn_dbc::{Dbc, DbcId, DbcIdSource, MainKey, PublicAddress, Token};
+use sn_dbc::{Dbc, DbcIdSource, MainKey, PublicAddress, Token};
 
 use async_trait::async_trait;
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
 
 /// A wallet that can send tokens to other addresses.
-pub struct LocalSendWallet<C: SendClient> {
+pub struct LocalSender<C: SendClient> {
     client: C,
-    wallet: LocalDepositWallet,
-}
-
-/// A wallet that can only receive tokens.
-pub struct LocalDepositWallet {
     /// The secret key with which we can access
     /// all the tokens in the available_dbcs.
     key: MainKey,
-    /// The current balance of the wallet.
-    balance: Token,
-    /// These are dbcs we've owned, that have been
-    /// spent when sending tokens to other addresses.
-    spent_dbcs: BTreeMap<DbcId, Dbc>,
-    /// These are the dbcs we own that are not yet spent.
-    available_dbcs: BTreeMap<DbcId, Dbc>,
-    /// These are the dbcs we've created by
-    /// sending tokens to other addresses.
-    /// They are not owned by us, but we
-    /// keep them here so we can track our
-    /// transfer history.
-    dbcs_created_for_others: Vec<CreatedDbc>,
-    // /// The path to the wallet file.
-    // local_store: std::path::PathBuf,
+    /// The wallet containing all data.
+    wallet: KeyLessWallet,
+    /// The path to the wallet file.
+    path: std::path::PathBuf,
 }
 
-impl DepositWallet for LocalDepositWallet {
-    fn new(key: MainKey) -> Self {
-        Self {
+/// A wallet that can only receive tokens.
+pub struct LocalDepositor {
+    /// The secret key with which we can access
+    /// all the tokens in the available_dbcs.
+    key: MainKey,
+    /// The wallet containing all data.
+    wallet: KeyLessWallet,
+    /// The path to the wallet file.
+    path: std::path::PathBuf,
+}
+
+impl LocalDepositor {
+    /// Stores the wallet to disk.
+    #[allow(dead_code)]
+    pub(crate) async fn store(&self) -> Result<()> {
+        store_wallet(&self.path, &self.wallet).await
+    }
+
+    /// Loads a serialized wallet from a path.
+    #[allow(dead_code)]
+    pub(crate) async fn load_from(path: &Path) -> Result<Self> {
+        let (key, wallet) = load_from_path(path).await?;
+        Ok(Self {
             key,
+            wallet,
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+impl<C: SendClient + Send + Sync + Clone> LocalSender<C> {
+    /// Stores the wallet to disk.
+    #[allow(dead_code)]
+    pub(crate) async fn store(&self) -> Result<()> {
+        store_wallet(&self.path, &self.wallet).await
+    }
+
+    /// Loads a serialized wallet from a path.
+    #[allow(dead_code)]
+    pub(crate) async fn load_from(path: &Path, client: C) -> Result<Self> {
+        let (key, wallet) = load_from_path(path).await?;
+        Ok(Self {
+            client,
+            key,
+            wallet,
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+/// Loads a serialized wallet from a path.
+async fn load_from_path(root_dir: &Path) -> Result<(MainKey, KeyLessWallet)> {
+    let key = match get_main_key(root_dir).await? {
+        Some(key) => key,
+        None => {
+            let key = MainKey::random();
+            store_new_keypair(root_dir, &key).await?;
+            key
+        }
+    };
+    let wallet = match get_wallet(root_dir).await? {
+        Some(wallet) => wallet,
+        None => {
+            let wallet = KeyLessWallet::new();
+            store_wallet(root_dir, &wallet).await?;
+            wallet
+        }
+    };
+
+    Ok((key, wallet))
+}
+
+impl KeyLessWallet {
+    fn new() -> Self {
+        Self {
             balance: Token::zero(),
             spent_dbcs: BTreeMap::new(),
             available_dbcs: BTreeMap::new(),
@@ -54,25 +116,11 @@ impl DepositWallet for LocalDepositWallet {
         }
     }
 
-    // /// Loads a serialized wallet from a path.
-    // fn load_from(path: &Path) -> Self {
-    //     Self {
-    //     }
-    // }
-
-    fn address(&self) -> PublicAddress {
-        self.key.public_address()
-    }
-
     fn balance(&self) -> Token {
         self.balance
     }
 
-    fn new_dbc_address(&self) -> DbcIdSource {
-        self.key.random_dbc_id_src(&mut rand::thread_rng())
-    }
-
-    fn deposit(&mut self, dbcs: Vec<Dbc>) {
+    fn deposit(&mut self, key: &MainKey, dbcs: Vec<Dbc>) {
         if dbcs.is_empty() {
             return;
         }
@@ -83,7 +131,7 @@ impl DepositWallet for LocalDepositWallet {
                 let id = dbc.id();
                 (!self.spent_dbcs.contains_key(&id)).then_some((id, dbc))
             })
-            .filter_map(|(id, dbc)| dbc.derived_key(&self.key).is_ok().then_some((id, dbc)))
+            .filter_map(|(id, dbc)| dbc.derived_key(key).is_ok().then_some((id, dbc)))
             .collect();
 
         self.available_dbcs.append(&mut received_dbcs);
@@ -91,10 +139,7 @@ impl DepositWallet for LocalDepositWallet {
         let new_balance = self
             .available_dbcs
             .iter()
-            .flat_map(|(_, dbc)| {
-                dbc.derived_key(&self.key)
-                    .map(|derived_key| (dbc, derived_key))
-            })
+            .flat_map(|(_, dbc)| dbc.derived_key(key).map(|derived_key| (dbc, derived_key)))
             .flat_map(|(dbc, derived_key)| dbc.revealed_input(&derived_key))
             .fold(0, |total, amount| total + amount.revealed_amount().value());
 
@@ -102,35 +147,40 @@ impl DepositWallet for LocalDepositWallet {
     }
 }
 
-#[async_trait]
-impl<C: SendClient + Send + Sync + Clone> SendWallet<C> for LocalSendWallet<C> {
-    fn new(key: MainKey, client: C) -> Self {
-        Self {
-            client,
-            wallet: LocalDepositWallet::new(key),
-        }
+impl DepositWallet for LocalDepositor {
+    fn address(&self) -> PublicAddress {
+        self.key.public_address()
     }
 
-    // /// Loads a serialized wallet from a path.
-    // fn load_from(path: &Path) -> Self {
-    //     Self {
-    //     }
-    // }
-
-    fn address(&self) -> PublicAddress {
-        self.wallet.address()
+    fn new_dbc_address(&self) -> DbcIdSource {
+        self.key.random_dbc_id_src(&mut rand::thread_rng())
     }
 
     fn balance(&self) -> Token {
         self.wallet.balance()
     }
 
+    fn deposit(&mut self, dbcs: Vec<Dbc>) {
+        self.wallet.deposit(&self.key, dbcs);
+    }
+}
+
+#[async_trait]
+impl<C: SendClient + Send + Sync + Clone> SendWallet<C> for LocalSender<C> {
+    fn address(&self) -> PublicAddress {
+        self.key.public_address()
+    }
+
     fn new_dbc_address(&self) -> DbcIdSource {
-        self.wallet.new_dbc_address()
+        self.key.random_dbc_id_src(&mut rand::thread_rng())
+    }
+
+    fn balance(&self) -> Token {
+        self.wallet.balance()
     }
 
     fn deposit(&mut self, dbcs: Vec<Dbc>) {
-        self.wallet.deposit(dbcs)
+        self.wallet.deposit(&self.key, dbcs);
     }
 
     async fn send(&mut self, to: Vec<(Token, PublicAddress)>) -> Result<Vec<CreatedDbc>> {
@@ -149,7 +199,7 @@ impl<C: SendClient + Send + Sync + Clone> SendWallet<C> for LocalSendWallet<C> {
 
         let mut available_dbcs = vec![];
         for dbc in self.wallet.available_dbcs.values() {
-            if let Ok(derived_key) = dbc.derived_key(&self.wallet.key) {
+            if let Ok(derived_key) = dbc.derived_key(&self.key) {
                 available_dbcs.push((dbc.clone(), derived_key));
             } else {
                 warn!(
@@ -187,78 +237,179 @@ impl<C: SendClient + Send + Sync + Clone> SendWallet<C> for LocalSendWallet<C> {
 
 #[cfg(test)]
 mod tests {
-    use super::{DepositWallet, LocalDepositWallet, Result, SendClient};
+    use super::{get_wallet, store_wallet, LocalDepositor, LocalSender};
 
     use crate::protocol::{
-        dbc_genesis::{create_genesis_dbc, GenesisResult, GENESIS_DBC_AMOUNT},
+        dbc_genesis::{create_genesis_dbc, GENESIS_DBC_AMOUNT},
         offline_transfers::{create_transfer, Outputs as TransferDetails},
-        wallet::{LocalSendWallet, SendWallet},
+        wallet::{keys::store_new_keypair, DepositWallet, KeyLessWallet, SendClient, SendWallet},
     };
 
     use sn_dbc::{Dbc, DbcIdSource, DerivedKey, MainKey, PublicAddress, Token};
+
+    use eyre::{eyre, Result};
+    use tempfile::{tempdir, TempDir};
+
+    #[tokio::test]
+    async fn keylesswallet_to_and_from_file() -> Result<()> {
+        let key = MainKey::random();
+        let mut wallet = KeyLessWallet::new();
+        let genesis = create_genesis_dbc(&key).expect("Genesis creation to succeed.");
+
+        let dir = create_temp_dir()?;
+        let path = &dir.path();
+
+        wallet.deposit(&key, vec![genesis]);
+
+        store_wallet(path, &wallet).await?;
+
+        let deserialized = get_wallet(path)
+            .await?
+            .expect("There to be a wallet on disk.");
+
+        assert_eq!(GENESIS_DBC_AMOUNT, wallet.balance().as_nano());
+        assert_eq!(GENESIS_DBC_AMOUNT, deserialized.balance().as_nano());
+
+        Ok(())
+    }
 
     /// -----------------------------------
     /// <-------> DepositWallet <--------->
     /// -----------------------------------
 
+    #[tokio::test]
+    async fn deposit_wallet_to_and_from_file() -> Result<()> {
+        let dir = create_temp_dir()?;
+        let path = &dir.path();
+
+        let key = MainKey::random();
+        store_new_keypair(path, &key).await?;
+
+        let genesis = create_genesis_dbc(&key).expect("Genesis creation to succeed.");
+
+        let mut deposit_only = LocalDepositor {
+            key,
+            wallet: KeyLessWallet::new(),
+            path: path.to_path_buf(),
+        };
+
+        deposit_only.deposit(vec![genesis]);
+        deposit_only.store().await?;
+
+        let deserialized = LocalDepositor::load_from(path).await?;
+
+        assert_eq!(deposit_only.address(), deserialized.address());
+        assert_eq!(GENESIS_DBC_AMOUNT, deposit_only.balance().as_nano());
+        assert_eq!(GENESIS_DBC_AMOUNT, deserialized.balance().as_nano());
+
+        assert_eq!(1, deposit_only.wallet.available_dbcs.len());
+        assert_eq!(0, deposit_only.wallet.dbcs_created_for_others.len());
+        assert_eq!(0, deposit_only.wallet.spent_dbcs.len());
+
+        assert_eq!(1, deserialized.wallet.available_dbcs.len());
+        assert_eq!(0, deserialized.wallet.dbcs_created_for_others.len());
+        assert_eq!(0, deserialized.wallet.spent_dbcs.len());
+
+        let a_available = deposit_only
+            .wallet
+            .available_dbcs
+            .values()
+            .last()
+            .expect("There to be an available DBC.");
+        let b_available = deserialized
+            .wallet
+            .available_dbcs
+            .values()
+            .last()
+            .expect("There to be an available DBC.");
+        assert_eq!(a_available, b_available);
+
+        Ok(())
+    }
+
     #[test]
     fn deposit_wallet_basics() -> Result<()> {
-        let main_key = MainKey::random();
-        let public_address = main_key.public_address();
-        let local_wallet: LocalDepositWallet = DepositWallet::new(main_key);
+        let key = MainKey::random();
+        let public_address = key.public_address();
+        let dir = create_temp_dir()?;
+        let path = dir.path().to_path_buf();
 
-        assert_eq!(public_address, local_wallet.address());
+        let deposit_only = LocalDepositor {
+            key,
+            wallet: KeyLessWallet::new(),
+            path,
+        };
+
+        assert_eq!(public_address, deposit_only.address());
         assert_eq!(
             public_address,
-            local_wallet.new_dbc_address().public_address
+            deposit_only.new_dbc_address().public_address
         );
-        assert_eq!(Token::zero(), local_wallet.balance());
+        assert_eq!(Token::zero(), deposit_only.balance());
 
-        assert!(local_wallet.available_dbcs.is_empty());
-        assert!(local_wallet.dbcs_created_for_others.is_empty());
-        assert!(local_wallet.spent_dbcs.is_empty());
+        assert!(deposit_only.wallet.available_dbcs.is_empty());
+        assert!(deposit_only.wallet.dbcs_created_for_others.is_empty());
+        assert!(deposit_only.wallet.spent_dbcs.is_empty());
 
         Ok(())
     }
 
     #[test]
     fn deposit_empty_list_does_nothing() -> Result<()> {
-        let mut local_wallet: LocalDepositWallet = DepositWallet::new(MainKey::random());
+        let dir = create_temp_dir()?;
+        let path = dir.path().to_path_buf();
 
-        local_wallet.deposit(vec![]);
+        let mut deposit_only = LocalDepositor {
+            key: MainKey::random(),
+            wallet: KeyLessWallet::new(),
+            path,
+        };
 
-        assert_eq!(Token::zero(), local_wallet.balance());
+        deposit_only.deposit(vec![]);
 
-        assert!(local_wallet.available_dbcs.is_empty());
-        assert!(local_wallet.dbcs_created_for_others.is_empty());
-        assert!(local_wallet.spent_dbcs.is_empty());
+        assert_eq!(Token::zero(), deposit_only.balance());
 
-        Ok(())
-    }
-
-    #[test]
-    #[allow(clippy::result_large_err)]
-    fn deposit_adds_dbcs_that_belongs_to_the_wallet() -> GenesisResult<()> {
-        let genesis_key = MainKey::random();
-        let genesis = create_genesis_dbc(&genesis_key)?;
-
-        let mut local_wallet: LocalDepositWallet = DepositWallet::new(genesis_key);
-
-        local_wallet.deposit(vec![genesis]);
-
-        assert_eq!(GENESIS_DBC_AMOUNT, local_wallet.balance().as_nano());
+        assert!(deposit_only.wallet.available_dbcs.is_empty());
+        assert!(deposit_only.wallet.dbcs_created_for_others.is_empty());
+        assert!(deposit_only.wallet.spent_dbcs.is_empty());
 
         Ok(())
     }
 
     #[test]
     #[allow(clippy::result_large_err)]
-    fn deposit_does_not_add_dbcs_not_belonging_to_the_wallet() -> GenesisResult<()> {
-        let genesis_key = MainKey::random();
-        let genesis = create_genesis_dbc(&genesis_key)?;
+    fn deposit_adds_dbcs_that_belongs_to_the_wallet() -> Result<()> {
+        let key = MainKey::random();
+        let genesis = create_genesis_dbc(&key).expect("Genesis creation to succeed.");
+        let dir = create_temp_dir()?;
+        let path = dir.path().to_path_buf();
 
-        let wallet_key = MainKey::random();
-        let mut local_wallet: LocalDepositWallet = DepositWallet::new(wallet_key);
+        let mut deposit_only = LocalDepositor {
+            key,
+            wallet: KeyLessWallet::new(),
+            path,
+        };
+
+        deposit_only.deposit(vec![genesis]);
+
+        assert_eq!(GENESIS_DBC_AMOUNT, deposit_only.balance().as_nano());
+
+        Ok(())
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn deposit_does_not_add_dbcs_not_belonging_to_the_wallet() -> Result<()> {
+        let genesis_key = MainKey::random();
+        let genesis = create_genesis_dbc(&genesis_key).expect("Genesis creation to succeed.");
+        let dir = create_temp_dir()?;
+        let path = dir.path().to_path_buf();
+
+        let mut local_wallet = LocalDepositor {
+            key: MainKey::random(),
+            wallet: KeyLessWallet::new(),
+            path,
+        };
 
         local_wallet.deposit(vec![genesis]);
 
@@ -273,19 +424,27 @@ mod tests {
 
     #[test]
     #[allow(clippy::result_large_err)]
-    fn send_wallet_basics() -> GenesisResult<()> {
-        let main_key = MainKey::random();
-        let public_address = main_key.public_address();
+    fn send_wallet_basics() -> Result<()> {
+        let key = MainKey::random();
+        let public_address = key.public_address();
         let client = MockSendClient;
-        let send_wallet: LocalSendWallet<MockSendClient> = SendWallet::new(main_key, client);
+        let dir = create_temp_dir()?;
+        let path = dir.path().to_path_buf();
 
-        assert_eq!(public_address, send_wallet.address());
-        assert_eq!(public_address, send_wallet.new_dbc_address().public_address);
-        assert_eq!(Token::zero(), send_wallet.balance());
+        let sender = LocalSender {
+            key,
+            wallet: KeyLessWallet::new(),
+            client,
+            path,
+        };
 
-        assert!(send_wallet.wallet.available_dbcs.is_empty());
-        assert!(send_wallet.wallet.dbcs_created_for_others.is_empty());
-        assert!(send_wallet.wallet.spent_dbcs.is_empty());
+        assert_eq!(public_address, sender.address());
+        assert_eq!(public_address, sender.new_dbc_address().public_address);
+        assert_eq!(Token::zero(), sender.balance());
+
+        assert!(sender.wallet.available_dbcs.is_empty());
+        assert!(sender.wallet.dbcs_created_for_others.is_empty());
+        assert!(sender.wallet.spent_dbcs.is_empty());
 
         Ok(())
     }
@@ -293,35 +452,135 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::result_large_err)]
     async fn sending_decreases_balance() -> Result<()> {
-        let sender_main_key = MainKey::random();
-        let sender_dbc =
-            create_genesis_dbc(&sender_main_key).expect("Genesis creation to succeed.");
+        let sender_key = MainKey::random();
+        let sender_dbc = create_genesis_dbc(&sender_key).expect("Genesis creation to succeed.");
 
         let client = MockSendClient;
-        let mut send_wallet: LocalSendWallet<MockSendClient> =
-            SendWallet::<MockSendClient>::new(sender_main_key, client);
+        let dir = create_temp_dir()?;
+        let path = dir.path().to_path_buf();
 
-        send_wallet.deposit(vec![sender_dbc]);
+        let mut sender = LocalSender {
+            key: sender_key,
+            wallet: KeyLessWallet::new(),
+            client,
+            path,
+        };
 
-        assert_eq!(GENESIS_DBC_AMOUNT, send_wallet.balance().as_nano());
+        sender.deposit(vec![sender_dbc]);
+
+        assert_eq!(GENESIS_DBC_AMOUNT, sender.balance().as_nano());
 
         // We send to a new address.
-        let recipient_main_key = MainKey::random();
-        let recipient_public_address = recipient_main_key.public_address();
-        let to = vec![(Token::from_nano(100), recipient_public_address)];
-        let created_dbcs = send_wallet.send(to).await?;
+        let send_amount = 100;
+        let recipient_key = MainKey::random();
+        let recipient_public_address = recipient_key.public_address();
+        let to = vec![(Token::from_nano(send_amount), recipient_public_address)];
+        let created_dbcs = sender.send(to).await?;
 
         assert_eq!(1, created_dbcs.len());
-        assert_eq!(GENESIS_DBC_AMOUNT - 100, send_wallet.balance().as_nano());
+        assert_eq!(GENESIS_DBC_AMOUNT - send_amount, sender.balance().as_nano());
 
         let recipient_dbc = &created_dbcs[0];
-        assert_eq!(100, recipient_dbc.amount.value());
+        assert_eq!(send_amount, recipient_dbc.amount.value());
         assert_eq!(
             &recipient_public_address,
             recipient_dbc.dbc.public_address()
         );
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn send_wallet_to_and_from_file() -> Result<()> {
+        let dir = create_temp_dir()?;
+        let path = &dir.path();
+
+        let sender_key = MainKey::random();
+        store_new_keypair(path, &sender_key).await?;
+
+        let sender_dbc = create_genesis_dbc(&sender_key).expect("Genesis creation to succeed.");
+        let client = MockSendClient;
+
+        let mut sender = LocalSender {
+            key: sender_key,
+            wallet: KeyLessWallet::new(),
+            client,
+            path: path.to_path_buf(),
+        };
+
+        sender.deposit(vec![sender_dbc]);
+
+        // We send to a new address.
+        let send_amount = 100;
+        let recipient_key = MainKey::random();
+        let recipient_public_address = recipient_key.public_address();
+        let to = vec![(Token::from_nano(send_amount), recipient_public_address)];
+        let _created_dbcs = sender.send(to).await?;
+
+        sender.store().await?;
+
+        let deserialized = LocalSender::load_from(path, MockSendClient).await?;
+
+        assert_eq!(sender.address(), deserialized.address());
+        assert_eq!(GENESIS_DBC_AMOUNT - send_amount, sender.balance().as_nano());
+        assert_eq!(
+            GENESIS_DBC_AMOUNT - send_amount,
+            deserialized.balance().as_nano()
+        );
+
+        assert_eq!(1, sender.wallet.available_dbcs.len());
+        assert_eq!(1, sender.wallet.dbcs_created_for_others.len());
+        assert_eq!(1, sender.wallet.spent_dbcs.len());
+
+        assert_eq!(1, deserialized.wallet.available_dbcs.len());
+        assert_eq!(1, deserialized.wallet.dbcs_created_for_others.len());
+        assert_eq!(1, deserialized.wallet.spent_dbcs.len());
+
+        let a_available = sender
+            .wallet
+            .available_dbcs
+            .values()
+            .last()
+            .expect("There to be an available DBC.");
+        let b_available = deserialized
+            .wallet
+            .available_dbcs
+            .values()
+            .last()
+            .expect("There to be an available DBC.");
+        assert_eq!(a_available, b_available);
+
+        let a_created_for_others = &sender.wallet.dbcs_created_for_others[0];
+        let b_created_for_others = &deserialized.wallet.dbcs_created_for_others[0];
+        assert_eq!(a_created_for_others.dbc, b_created_for_others.dbc);
+        assert_eq!(
+            a_created_for_others.amount.value,
+            b_created_for_others.amount.value
+        );
+        assert_eq!(
+            a_created_for_others.amount.blinding_factor,
+            b_created_for_others.amount.blinding_factor
+        );
+
+        let a_spent = sender
+            .wallet
+            .spent_dbcs
+            .values()
+            .last()
+            .expect("There to be a spent DBC.");
+        let b_spent = deserialized
+            .wallet
+            .spent_dbcs
+            .values()
+            .last()
+            .expect("There to be a spent DBC.");
+        assert_eq!(a_spent, b_spent);
+
+        Ok(())
+    }
+
+    fn create_temp_dir() -> Result<TempDir> {
+        tempdir().map_err(|e| eyre!("Failed to create temp dir: {}", e))
     }
 
     #[derive(Clone)]
@@ -334,7 +593,7 @@ mod tests {
             dbcs: Vec<(Dbc, DerivedKey)>,
             to: Vec<(Token, DbcIdSource)>,
             change_to: PublicAddress,
-        ) -> Result<TransferDetails> {
+        ) -> super::Result<TransferDetails> {
             // Here we just create a transfer, without network calls,
             // and without sending it to the network.
             let transfer = create_transfer(dbcs, to, change_to)

--- a/safenode/src/protocol/wallet/wallet_file.rs
+++ b/safenode/src/protocol/wallet/wallet_file.rs
@@ -1,0 +1,36 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{error::Result, KeyLessWallet};
+
+use std::path::Path;
+use tokio::fs;
+
+// Filename for storing a wallet.
+const WALLET_FILENAME: &str = "wallet";
+
+/// Writes the `KeyLessWallet` to the specified path.
+pub(super) async fn store_wallet(root_dir: &Path, wallet: &KeyLessWallet) -> Result<()> {
+    let wallet_path = root_dir.join(WALLET_FILENAME);
+    let bytes = bincode::serialize(&wallet)?;
+    fs::write(wallet_path, bytes).await?;
+    Ok(())
+}
+
+/// Returns `Some(KeyLessWallet)` or None if file doesn't exist.
+pub(super) async fn get_wallet(root_dir: &Path) -> Result<Option<KeyLessWallet>> {
+    let path = root_dir.join(WALLET_FILENAME);
+    if !path.is_file() {
+        return Ok(None);
+    }
+
+    let bytes = fs::read(&path).await?;
+    let wallet = bincode::deserialize(&bytes)?;
+
+    Ok(Some(wallet))
+}


### PR DESCRIPTION
Resolves #89.

[feat(wallet): store and load from disk](https://github.com/maidsafe/stableset_net/commit/7ba6c521c43807592a765ff7c6387567b8acf3ff) 
As a temporary solution, the serialized wallet can be stored to disk.
Next the wallet ops will be stored to disk as a Register.
 
[chore(wallet): use load_from in tests](https://github.com/maidsafe/stableset_net/commit/e159431eb88d4d55d762643e36b2b2d208744379) 
This auto-generates a new mainkey.
 
[feat(client): instantiate wallet in client](https://github.com/maidsafe/stableset_net/commit/a57ea01925f7d69fac4cba43b4b28c49b649f354)