### PR TITLE
ci: remove merge workflow run on push to main

### DIFF
--- a/.github/workflows/daily_run.yml
+++ b/.github/workflows/daily_run.yml
@@ -1,4 +1,4 @@
-name: Full Network Tests for daily run
+name: Nightly: Full Network Tests
 
 on:
   schedule:
@@ -7,6 +7,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
   NODE_COUNT: 14
+  WORKFLOW_URL: https://github.com/maidsafe/stableset_net/actions/runs
 
 jobs:
   e2e:
@@ -94,3 +95,11 @@ jobs:
           path: log_files.tar.gz
         if: failure()
         continue-on-error: true
+
+      - name: post notification to slack on failure
+        if: ${{ failure() }}
+        uses: bryannice/gitactions-slack-notification@2.0.0
+        env:
+          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+          SLACK_TITLE: "Nightly Test Run Failed"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,12 +1,6 @@
 name: Check before merge
 
 on:
-  # on main, we want to know that all commits are passing at a glance, any deviation should help debugging errors at a glance
-  push:
-    branches: [main]
-  # tests must run for a PR to be valid and pass merge queue muster
-  merge_group:
-    branches: [main]
   pull_request:
     branches: ["*"]
 
@@ -31,7 +25,6 @@ jobs:
         run: cargo install cargo-udeps --locked
       - name: Run cargo-udeps
         run: cargo +nightly udeps --all-targets
-
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since we are trying to only run unit tests on the merge workflow, these tests should be deterministic and should not require other runs for extra verification.

Also added notifications for failures for the nightly full test run.