### PR TITLE
feat(node): dial peers on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stableset_net
+# The Safe Network
 
 This is the Safe Network as it was supposed to be, on a kademlia network, enabled by libp2p.
 
@@ -44,7 +44,10 @@ cargo run --release --example registers -- --user bob --reg-nickname myregister
 
 ### TODO
 
-- [ ] Basic messaging to target nodes
 - [ ] Add RPC for simplest node/net interaction (do libp2p CLIs help here?)
-- [ ] Add in chunking etc
-- [ ] Add in DBCs and validation handling
+
+
+
+### Archive
+
+The elder-membership agreed, section tree backed implementation of the safe network can be found [here](https://github.com/maidsafe/safe_network_archive)

--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -70,6 +70,8 @@ impl Client {
         match event {
             // Clients do not handle requests.
             NetworkEvent::RequestReceived { .. } => {}
+            // We do not listen on sockets.
+            NetworkEvent::NewListenAddr(_) => {}
             NetworkEvent::PeerAdded => {
                 self.events_channel
                     .broadcast(ClientEvent::ConnectedToNetwork);

--- a/safenode/src/node/mod.rs
+++ b/safenode/src/node/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     storage::{ChunkStorage, RegisterStorage},
 };
 
-use libp2p::PeerId;
+use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
 use xor_name::{XorName, XOR_NAME_LEN};
 
@@ -33,6 +33,8 @@ pub struct Node {
     registers: RegisterStorage,
     transfers: Transfers,
     events_channel: NodeEventsChannel,
+    /// Peers that are dialed at startup of node.
+    initial_peers: Vec<(PeerId, Multiaddr)>,
 }
 
 /// A unique identifier for a node in the network,


### PR DESCRIPTION
We dial optional peers on startup that will get added to our routing
table et al. This will cause our node to get booted by specifying a
bootstrap node address.
